### PR TITLE
Changes

### DIFF
--- a/simbad/command_line/__init__.py
+++ b/simbad/command_line/__init__.py
@@ -45,6 +45,8 @@ def _argparse_core_options(p):
                     action="store_true", help="Show the SIMBAD Gui")
     sg.add_argument('--process_all', default=False,
                     action="store_true", help="Trial all search models")
+    sg.add_argument('--skip_mr', default=False,
+                    action="store_true", help="Skip Molecular replacement step")
     sg.add_argument('--version', action='version', version='SIMBAD v{0}'.format(simbad.version.__version__),
                     help='Print the SIMBAD version')
 
@@ -70,7 +72,7 @@ def _argparse_contaminant_options(p):
                     help="The maximum number of contaminant results to return")
     sg.add_argument('-organism', type=str,
                     help="Select a specific host organism using the UniProt mnemonic organism"
-                    "identification code")
+                         "identification code")
 
 
 def _argparse_morda_options(p):
@@ -158,7 +160,6 @@ def _simbad_contaminant_search(args):
 
     """
     from simbad.rotsearch.amore_search import AmoreRotationSearch
-    from simbad.mr import MrSubmit, mr_succeeded_csvfile
 
     logger = logging.getLogger(__name__)
     stem = os.path.join(args.work_dir, 'cont')
@@ -194,22 +195,18 @@ def _simbad_contaminant_search(args):
                             submit_qtype=args.submit_qtype,
                             submit_queue=args.submit_queue,
                             chunk_size=args.chunk_size)
+
     if rotation_search.search_results:
         rot_summary_f = os.path.join(stem, 'rot_search.csv')
         logger.debug("Contaminant search summary file: %s", rot_summary_f)
         rotation_search.summarize(rot_summary_f)
-        contaminant_output_dir = os.path.join(stem, 'mr_search')
-        molecular_replacement = MrSubmit(temp_mtz, args.mr_program,
-                                         args.refine_program,
-                                         contaminant_model_dir,
-                                         contaminant_output_dir,
-                                         enant=args.enan,
-                                         timeout=args.phaser_kill)
-        molecular_replacement.submit_jobs(rotation_search.search_results,
-                                          nproc=args.nproc,
-                                          process_all=args.process_all,
-                                          submit_qtype=args.submit_qtype,
-                                          submit_queue=args.submit_queue)
+
+    if not args.skip_mr:
+        from simbad.mr import mr_succeeded_csvfile
+
+        contaminant_mr_dir = os.path.join(stem, 'mr_search')
+        molecular_replacement = submit_mr_jobs(temp_mtz, contaminant_model_dir, contaminant_mr_dir,
+                                               rotation_search.search_results, args)
         mr_summary_f = os.path.join(stem, 'cont_mr.csv')
         logger.debug("Contaminant MR summary file: %s", mr_summary_f)
         molecular_replacement.summarize(mr_summary_f)
@@ -233,7 +230,6 @@ def _simbad_morda_search(args):
 
     """
     from simbad.rotsearch.amore_search import AmoreRotationSearch
-    from simbad.mr import MrSubmit, mr_succeeded_csvfile
 
     logger = logging.getLogger(__name__)
     stem = os.path.join(args.work_dir, 'morda')
@@ -267,16 +263,12 @@ def _simbad_morda_search(args):
         rot_summary_f = os.path.join(stem, 'rot_search.csv')
         logger.debug("MoRDa search summary file: %s", rot_summary_f)
         rotation_search.summarize(rot_summary_f)
-        morda_output_dir = os.path.join(stem, 'mr_search')
-        molecular_replacement = MrSubmit(temp_mtz, args.mr_program,
-                                         args.refine_program, morda_model_dir,
-                                         morda_output_dir, enant=args.enan,
-                                         timeout=args.phaser_kill)
-        molecular_replacement.submit_jobs(rotation_search.search_results,
-                                          nproc=args.nproc,
-                                          process_all=args.process_all,
-                                          submit_qtype=args.submit_qtype,
-                                          submit_queue=args.submit_queue)
+
+    if not args.skip_mr:
+        from simbad.mr import mr_succeeded_csvfile
+        morda_mr_dir = os.path.join(stem, 'mr_search')
+        molecular_replacement = submit_mr_jobs(temp_mtz, morda_model_dir, morda_mr_dir,
+                                               rotation_search.search_results, args)
         mr_summary_f = os.path.join(stem, 'morda_mr.csv')
         logger.debug("MoRDa search MR summary file: %s", mr_summary_f)
         molecular_replacement.summarize(mr_summary_f)
@@ -303,7 +295,6 @@ def _simbad_lattice_search(args):
 
     """
     from simbad.lattice.latticesearch import LatticeSearch
-    from simbad.mr import MrSubmit, mr_succeeded_csvfile
 
     MTZ_AVAIL = args.mtz is not None
     temp_mtz = None
@@ -332,7 +323,9 @@ def _simbad_lattice_search(args):
         latt_summary_f = os.path.join(stem, 'lattice_search.csv')
         ls.summarize(latt_summary_f)
 
-    if MTZ_AVAIL:
+    if MTZ_AVAIL and not args.skip_mr:
+        from simbad.mr import mr_succeeded_csvfile
+
         if args.pdb_db:
             ls.copy_results(args.pdb_db, lattice_mod_dir)
         else:
@@ -345,14 +338,7 @@ def _simbad_lattice_search(args):
         lattice_mr_dir = os.path.join(stem, 'mr_search')
         os.makedirs(lattice_mr_dir)
 
-        molecular_replacement = MrSubmit(temp_mtz, args.mr_program,
-                                         args.refine_program, lattice_mod_dir,
-                                         lattice_mr_dir, enant=args.enan,
-                                         timeout=args.phaser_kill)
-        molecular_replacement.submit_jobs(ls.results, nproc=args.nproc,
-                                          process_all=args.process_all,
-                                          submit_qtype=args.submit_qtype,
-                                          submit_queue=args.submit_queue)
+        molecular_replacement = submit_mr_jobs(temp_mtz, lattice_mod_dir, lattice_mr_dir, ls.results, args)
         mr_summary_f = os.path.join(stem, 'lattice_mr.csv')
         logger.debug("Lattice search MR summary file: %s", mr_summary_f)
         molecular_replacement.summarize(mr_summary_f)
@@ -490,7 +476,7 @@ def print_header():
     logger.info("%(sep)s%(hashish)s%(sep)s%(hashish)s%(sep)s%(hashish)s%(sep)s#%(line)s#%(sep)s%(hashish)s%(sep)s",
                 {'hashish': '#' * nhashes, 'sep': os.linesep,
                  'line': 'SIMBAD - Sequence Independent Molecular '
-                 'replacement Based on Available Database'.center(nhashes - 2, ' ')}
+                         'replacement Based on Available Database'.center(nhashes - 2, ' ')}
                 )
     logger.info("SIMBAD version: %s", simbad.version.__version__)
     logger.info("Running with CCP4 version: %s from directory: %s",
@@ -525,13 +511,14 @@ def setup_logging(level='info', logfile=None, debug_logfile=None):
        Instance of a :obj:`logger <logging.Logger>`
 
     """
+
     class ColorFormatter(logging.Formatter):
         """Formatter to color console logging output"""
         colors = {
-            "DEBUG": 34,           # blue
-            "WARNING": 33,         # yellow
-            "ERROR": 31,           # red
-            "CRITICAL": 31,        # red
+            "DEBUG": 34,  # blue
+            "WARNING": 33,  # yellow
+            "ERROR": 31,  # red
+            "CRITICAL": 31,  # red
         }
 
         def format(self, record):
@@ -579,3 +566,35 @@ def setup_logging(level='info', logfile=None, debug_logfile=None):
     logging.getLogger().debug('File logger level: %s', logging.NOTSET)
 
     return logging.getLogger()
+
+
+def submit_mr_jobs(mtz, models_dir, mr_dir, search_results, args):
+    """Function to submit molecular replacement jobs
+
+    Parameters
+    ----------
+    mtz : str
+        Path to input mtz file
+    models_dir : str
+        Path to input models directory
+    mr_dir : str
+        Path to directory where MR will be run
+    search_results : list
+        list of results from SIMBAD search
+
+    Returns
+    -------
+    object
+        MrSubmit object containing results from MR
+    """
+    from simbad.mr import MrSubmit
+    molecular_replacement = MrSubmit(mtz, args.mr_program,
+                                     args.refine_program, models_dir,
+                                     mr_dir, enant=args.enan,
+                                     timeout=args.phaser_kill)
+    molecular_replacement.submit_jobs(search_results,
+                                      nproc=args.nproc,
+                                      process_all=args.process_all,
+                                      submit_qtype=args.submit_qtype,
+                                      submit_queue=args.submit_queue)
+    return molecular_replacement

--- a/simbad/lattice/latticescore.py
+++ b/simbad/lattice/latticescore.py
@@ -8,11 +8,13 @@ __version__ = "0.1"
 class LatticeSearchResult(object):
     """A basic lattice parameter scoring class"""
 
-    __slots__ = ('pdb_code', 'alt', 'unit_cell', 'volume_difference', 'total_penalty', 'length_penalty', 'angle_penalty',
+    __slots__ = ('pdb_code', 'pdb_path','alt', 'unit_cell', 'volume_difference', 'total_penalty', 'length_penalty', 'angle_penalty',
                  'probability_score')
 
-    def __init__(self, pdb_code, alt, unit_cell, volume_difference, total_penalty, length_penalty, angle_penalty, probability_score):
+    def __init__(self, pdb_code, pdb_path, alt, unit_cell, volume_difference, total_penalty, length_penalty,
+                 angle_penalty, probability_score):
         self.pdb_code = pdb_code
+        self.pdb_path = pdb_path
         self.alt = alt
         self.unit_cell = unit_cell
         self.volume_difference = volume_difference
@@ -22,9 +24,9 @@ class LatticeSearchResult(object):
         self.probability_score = probability_score
 
     def __repr__(self):
-        template = "{name}(pdb_code={pdb_code} alt={alt} unit_cell={unit_cell} volume_difference={volume_difference} " \
-                   "total_penalty={total_penalty} length_penalty={length_penalty} angle_penalty={angle_penalty} " \
-                   "probability_score={probability_score}"
+        template = "{name}(pdb_code={pdb_code} pdb_path={pdb_path} alt={alt} unit_cell={unit_cell} " \
+                   "volume_difference={volume_difference} total_penalty={total_penalty} " \
+                   "length_penalty={length_penalty} angle_penalty={angle_penalty} probability_score={probability_score}"
         return template.format(self.__class__.__name__, **{k: getattr(self, k) for k in self.__class__.__slots__})
 
     def _as_dict(self):

--- a/simbad/lattice/latticescore.py
+++ b/simbad/lattice/latticescore.py
@@ -23,8 +23,8 @@ class LatticeSearchResult(object):
 
     def __repr__(self):
         template = "{name}(pdb_code={pdb_code} alt={alt} unit_cell={unit_cell} volume_difference={volume_difference} " \
-                   + "total_penalty={total_penalty} length_penalty={length_penalty} angle_penalty={angle_penalty} " \
-                   + "probability_score={probability_score}"
+                   "total_penalty={total_penalty} length_penalty={length_penalty} angle_penalty={angle_penalty} " \
+                   "probability_score={probability_score}"
         return template.format(self.__class__.__name__, **{k: getattr(self, k) for k in self.__class__.__slots__})
 
     def _as_dict(self):

--- a/simbad/lattice/latticesearch.py
+++ b/simbad/lattice/latticesearch.py
@@ -26,7 +26,7 @@ class LatticeSearch(object):
 
     """
 
-    def __init__(self, lattice_db_fname, working_dir):
+    def __init__(self, lattice_db_fname, model_dir):
         """Initialize a new Lattice Search class
 
         Parameters
@@ -38,10 +38,10 @@ class LatticeSearch(object):
 
         """
         self._lattice_db_fname = None
-        self._working_dir = None
+        self._model_dir = None
 
         self.lattice_db_fname = lattice_db_fname
-        self.working_dir = working_dir
+        self.model_dir = model_dir
 
         self.results = []
 
@@ -62,14 +62,14 @@ class LatticeSearch(object):
         self._lattice_db_fname = lattice_db_fname
 
     @property
-    def working_dir(self):
-        """The path to the working directory"""
-        return self._working_dir
+    def model_dir(self):
+        """The path to the model directory"""
+        return self._model_dir
 
-    @working_dir.setter
-    def working_dir(self, working_dir):
-        """Define the working directory"""
-        self._working_dir = working_dir
+    @model_dir.setter
+    def model_dir(self, model_dir):
+        """Define the model directory"""
+        self._model_dir = model_dir
 
     def search(self, space_group, unit_cell, tolerance=0.05, max_to_keep=50, max_penalty=12):
         """Search for similar Niggli cells
@@ -99,7 +99,7 @@ class LatticeSearch(object):
         with numpy.load(self.lattice_db_fname) as compressed:
             for entry in compressed["arr_0"]:
                 pdb_code = "".join(chr(c) for c in entry[:4].astype('uint8'))
-                pdb_path = os.path.join(self.working_dir, 'mr_models', '{0}.pdb'.format(pdb_code))
+                pdb_path = os.path.join(self.model_dir, '{0}.pdb'.format(pdb_code))
                 alt_cell = chr(int(entry[4])) if entry[4] != 0.0 else ' '
                 db_cell = entry[5:]
 

--- a/simbad/lattice/latticesearch.py
+++ b/simbad/lattice/latticesearch.py
@@ -70,7 +70,7 @@ class LatticeSearch(object):
            The tolerance applied for Niggli cell comparison [default: 0.05]
         max_to_keep : int, optional
            The top-N number of results to return [default: 50]
-        penalty_cut_off : int, optional
+        max_penalty : int, optional
            The total penalty score over which results are ignored [default: 12]
 
         """

--- a/simbad/mr/__init__.py
+++ b/simbad/mr/__init__.py
@@ -70,26 +70,24 @@ class MrSubmit(object):
         Name of the molecular replacement program to use
     refine_program : str
         Name of the refinement program to use
-    model_dir : str
-        Path to the directory containing input models
     output_dir : str
         Path to the directory to output results
     enant : bool
         Test enantimorphic space groups [default: False]
-    search_results : obj
+    results : obj
         Results from :obj: '_LatticeParameterScore' or :obj: '_AmoreRotationScore'
 
     Examples
     --------
     >>> from simbad.mr import MrSubmit
-    >>> MR = MrSubmit('<mtz>', '<mr_program>', '<refine_program>', '<model_dir>', '<output_dir>', '<enam>')
+    >>> MR = MrSubmit('<mtz>', '<mr_program>', '<refine_program>', '<output_dir>', '<enam>')
     >>> MR.submit_jobs('<results>', '<nproc>', '<submit_cluster>', '<submit_qtype>', '<submit_queue>',
     ...                '<submit_array>', '<submit_max_array>', '<timeout>', '<process_all>', '<monitor>')
 
     If a solution is found and process_all is not set, the queued jobs will be terminated.
     """
 
-    def __init__(self, mtz, mr_program, refine_program, model_dir, output_dir, timeout, enant=False):
+    def __init__(self, mtz, mr_program, refine_program, output_dir, timeout, enant=False):
         """Initialise MrSubmit class"""
         self.input_file = None
         self._process_all = None
@@ -114,7 +112,6 @@ class MrSubmit(object):
         self._free = None
 
         self.enant = enant
-        self.model_dir = os.path.abspath(model_dir)
         self.mtz = mtz
         self.mr_program = mr_program
         self.output_dir = output_dir
@@ -328,8 +325,7 @@ class MrSubmit(object):
 
         run_files = []
         for result in results:
-            mr_pdbin = os.path.join(
-                self.model_dir, '{0}.pdb'.format(result.pdb_code))
+            mr_pdbin = result.pdb_path
             mr_workdir = os.path.join(
                 self.output_dir, result.pdb_code, 'mr', self.mr_program)
             mr_logfile = os.path.join(

--- a/simbad/rotsearch/amore_score.py
+++ b/simbad/rotsearch/amore_score.py
@@ -1,0 +1,38 @@
+"""Class to store AMORE rotation scores"""
+
+__author__ = "Adam Simpkin & Felix Simkovic"
+__date__ = "10 Oct 2017"
+__version__ = "0.1"
+
+
+class AmoreRotationScore(object):
+    """An amore rotation scoring class"""
+
+    __slots__ = ("pdb_code", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
+                 "CC_F_Z_score", "CC_P_Z_score", "Number_of_rotation_searches_producing_peak")
+
+    def __init__(self, pdb_code, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
+                 CC_F_Z_score, CC_P_Z_score, Number_of_rotation_searches_producing_peak):
+        self.pdb_code = pdb_code
+        self.ALPHA = ALPHA
+        self.BETA = BETA
+        self.GAMMA = GAMMA
+        self.CC_F = CC_F
+        self.RF_F = RF_F
+        self.CC_I = CC_I
+        self.CC_P = CC_P
+        self.Icp = Icp
+        self.CC_F_Z_score = CC_F_Z_score
+        self.CC_P_Z_score = CC_P_Z_score
+        self.Number_of_rotation_searches_producing_peak = Number_of_rotation_searches_producing_peak
+
+    def __repr__(self):
+        string = "{name}(pdb_code={pdb_code} ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} CC_F=CC_F RF_F={RF_F} " \
+                 "CC_I={CC_I} CC_P={CC_P} Icp={Icp} CC_F_Z_score={CC_F_Z_score} CC_P_Z_score={CC_P_Z_score} " \
+                 "Number_of_rotation_searches_producing_peak={Number_of_rotation_searches_producing_peak})"
+        return string.format(name=self.__class__.__name__, **{k: getattr(self, k) for k in self.__slots__})
+
+    def _as_dict(self):
+        """Convert the :obj:`_AmoreRotationScore <simbad.rotsearch.amore_search._AmoreRotationScore>`
+        object to a dictionary"""
+        return {k: getattr(self, k) for k in self.__slots__}

--- a/simbad/rotsearch/amore_score.py
+++ b/simbad/rotsearch/amore_score.py
@@ -8,12 +8,13 @@ __version__ = "0.1"
 class AmoreRotationScore(object):
     """An amore rotation scoring class"""
 
-    __slots__ = ("pdb_code", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
+    __slots__ = ("pdb_code", "pdb_path", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
                  "CC_F_Z_score", "CC_P_Z_score", "Number_of_rotation_searches_producing_peak")
 
-    def __init__(self, pdb_code, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
+    def __init__(self, pdb_code, pdb_path, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
                  CC_F_Z_score, CC_P_Z_score, Number_of_rotation_searches_producing_peak):
         self.pdb_code = pdb_code
+        self.pdb_path = pdb_path
         self.ALPHA = ALPHA
         self.BETA = BETA
         self.GAMMA = GAMMA
@@ -27,8 +28,9 @@ class AmoreRotationScore(object):
         self.Number_of_rotation_searches_producing_peak = Number_of_rotation_searches_producing_peak
 
     def __repr__(self):
-        string = "{name}(pdb_code={pdb_code} ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} CC_F=CC_F RF_F={RF_F} " \
-                 "CC_I={CC_I} CC_P={CC_P} Icp={Icp} CC_F_Z_score={CC_F_Z_score} CC_P_Z_score={CC_P_Z_score} " \
+        string = "{name}(pdb_code={pdb_code} pdb_path={pdb_path} ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} " \
+                 "CC_F=CC_F RF_F={RF_F} CC_I={CC_I} CC_P={CC_P} Icp={Icp} " \
+                 "CC_F_Z_score={CC_F_Z_score} CC_P_Z_score={CC_P_Z_score} " \
                  "Number_of_rotation_searches_producing_peak={Number_of_rotation_searches_producing_peak})"
         return string.format(name=self.__class__.__name__, **{k: getattr(self, k) for k in self.__slots__})
 

--- a/simbad/rotsearch/amore_score.py
+++ b/simbad/rotsearch/amore_score.py
@@ -8,12 +8,13 @@ __version__ = "0.1"
 class AmoreRotationScore(object):
     """An amore rotation scoring class"""
 
-    __slots__ = ("pdb_code", "pdb_path", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
+    __slots__ = ("pdb_code", "dat_path", "pdb_path", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
                  "CC_F_Z_score", "CC_P_Z_score", "Number_of_rotation_searches_producing_peak")
 
-    def __init__(self, pdb_code, pdb_path, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
+    def __init__(self, pdb_code, dat_path, pdb_path, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
                  CC_F_Z_score, CC_P_Z_score, Number_of_rotation_searches_producing_peak):
         self.pdb_code = pdb_code
+        self.dat_path = dat_path
         self.pdb_path = pdb_path
         self.ALPHA = ALPHA
         self.BETA = BETA
@@ -28,7 +29,8 @@ class AmoreRotationScore(object):
         self.Number_of_rotation_searches_producing_peak = Number_of_rotation_searches_producing_peak
 
     def __repr__(self):
-        string = "{name}(pdb_code={pdb_code} pdb_path={pdb_path} ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} " \
+        string = "{name}(pdb_code={pdb_code} dat_path={dat_path} pdb_path={pdb_path} " \
+                 "ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} " \
                  "CC_F=CC_F RF_F={RF_F} CC_I={CC_I} CC_P={CC_P} Icp={Icp} " \
                  "CC_F_Z_score={CC_F_Z_score} CC_P_Z_score={CC_P_Z_score} " \
                  "Number_of_rotation_searches_producing_peak={Number_of_rotation_searches_producing_peak})"

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -6,7 +6,6 @@ __version__ = "0.2"
 
 import base64
 import logging
-import glob
 import numpy
 import os
 import shutil
@@ -16,6 +15,7 @@ from pyjob import Job, cexec
 from pyjob.misc import make_script, tmp_file
 
 from simbad.parsers import rotsearch_parser
+from simbad.rotsearch import amore_score
 from simbad.util import matthews_coef
 from simbad.util import mtz_util
 
@@ -25,39 +25,6 @@ import iotbx.pdb.mining
 logger = logging.getLogger(__name__)
 
 EXPORT = "SET" if os.name == "nt" else "export"
-
-
-class _AmoreRotationScore(object):
-    """An amore rotation scoring class"""
-
-    __slots__ = ("pdb_code", "ALPHA", "BETA", "GAMMA", "CC_F", "RF_F", "CC_I", "CC_P", "Icp",
-                 "CC_F_Z_score", "CC_P_Z_score", "Number_of_rotation_searches_producing_peak")
-
-    def __init__(self, pdb_code, ALPHA, BETA, GAMMA, CC_F, RF_F, CC_I, CC_P, Icp,
-                 CC_F_Z_score, CC_P_Z_score, Number_of_rotation_searches_producing_peak):
-        self.pdb_code = pdb_code
-        self.ALPHA = ALPHA
-        self.BETA = BETA
-        self.GAMMA = GAMMA
-        self.CC_F = CC_F
-        self.RF_F = RF_F
-        self.CC_I = CC_I
-        self.CC_P = CC_P
-        self.Icp = Icp
-        self.CC_F_Z_score = CC_F_Z_score
-        self.CC_P_Z_score = CC_P_Z_score
-        self.Number_of_rotation_searches_producing_peak = Number_of_rotation_searches_producing_peak
-
-    def __repr__(self):
-        string = "{name}(pdb_code={pdb_code} ALPHA={ALPHA} BETA={BETA} GAMMA={GAMMA} CC_F=CC_F RF_F={RF_F} " \
-                 "CC_I={CC_I} CC_P={CC_P} Icp={Icp} CC_F_Z_score={CC_F_Z_score} CC_P_Z_score={CC_P_Z_score} " \
-                 "Number_of_rotation_searches_producing_peak={Number_of_rotation_searches_producing_peak})"
-        return string.format(name=self.__class__.__name__, **{k: getattr(self, k) for k in self.__slots__})
-
-    def _as_dict(self):
-        """Convert the :obj:`_AmoreRotationScore <simbad.rotsearch.amore_search._AmoreRotationScore>`
-        object to a dictionary"""
-        return {k: getattr(self, k) for k in self.__slots__}
 
 
 class AmoreRotationSearch(object):
@@ -530,8 +497,9 @@ class AmoreRotationSearch(object):
                     pdb_code = os.path.basename(rot_log).replace(
                         "rotfun_", "").replace(".log", "")
                     RP = rotsearch_parser.RotsearchParser(rot_log)
-                    score = _AmoreRotationScore(pdb_code, RP.alpha, RP.beta, RP.gamma, RP.cc_f, RP.rf_f, RP.cc_i,
-                                                RP.cc_p, RP.icp, RP.cc_f_z_score, RP.cc_p_z_score, RP.num_of_rot)
+                    score = amore_score.AmoreRotationScore(pdb_code, RP.alpha, RP.beta, RP.gamma, RP.cc_f, RP.rf_f,
+                                                           RP.cc_i, RP.cc_p, RP.icp, RP.cc_f_z_score, RP.cc_p_z_score,
+                                                           RP.num_of_rot)
                     if RP.cc_f_z_score is not None:
                         results += [score]
                         if os.path.isfile(input_model):

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -496,8 +496,9 @@ class AmoreRotationSearch(object):
                 for input_model, rot_log in rotation_data:
                     pdb_code = os.path.basename(rot_log).replace(
                         "rotfun_", "").replace(".log", "")
+                    pdb_path = os.path.join(output_model_dir, os.path.basename(input_model))
                     RP = rotsearch_parser.RotsearchParser(rot_log)
-                    score = amore_score.AmoreRotationScore(pdb_code, input_model, RP.alpha, RP.beta, RP.gamma, RP.cc_f,
+                    score = amore_score.AmoreRotationScore(pdb_code, pdb_path, RP.alpha, RP.beta, RP.gamma, RP.cc_f,
                                                            RP.rf_f, RP.cc_i, RP.cc_p, RP.icp, RP.cc_f_z_score,
                                                            RP.cc_p_z_score, RP.num_of_rot)
                     if RP.cc_f_z_score is not None:

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -417,7 +417,7 @@ class AmoreRotationSearch(object):
                     solvent_content = matthews_coef.solvent_content(input_model,
                                                                     cell_parameters,
                                                                     space_group)
-                except:
+                except ValueError:
                     logger.critical("Error calculating solvent content for %s",
                                     name)
                     continue
@@ -497,9 +497,9 @@ class AmoreRotationSearch(object):
                     pdb_code = os.path.basename(rot_log).replace(
                         "rotfun_", "").replace(".log", "")
                     RP = rotsearch_parser.RotsearchParser(rot_log)
-                    score = amore_score.AmoreRotationScore(pdb_code, RP.alpha, RP.beta, RP.gamma, RP.cc_f, RP.rf_f,
-                                                           RP.cc_i, RP.cc_p, RP.icp, RP.cc_f_z_score, RP.cc_p_z_score,
-                                                           RP.num_of_rot)
+                    score = amore_score.AmoreRotationScore(pdb_code, input_model, RP.alpha, RP.beta, RP.gamma, RP.cc_f,
+                                                           RP.rf_f, RP.cc_i, RP.cc_p, RP.icp, RP.cc_f_z_score,
+                                                           RP.cc_p_z_score, RP.num_of_rot)
                     if RP.cc_f_z_score is not None:
                         results += [score]
                         if os.path.isfile(input_model):


### PR DESCRIPTION
Refactored MR submission:
- Created separate mr_submit function
- flag to skip mr (This allows just the lattice/rotation searches to be run from an input mtz)
- Use path to search model stored in search_results object in mr module

Altered scoring classes
- To store search model path
- Separated out amore scoring class from amore search

Deleted input_models
- Delete mr_input_model dir at the end of the job to save space
- Note, cannot do this immediately after the rotation step as Ronan suggested as the search models are needed for MR