### PR TITLE
Bug fix and performance improvement for rotation search

### DIFF
--- a/simbad/db/__init__.py
+++ b/simbad/db/__init__.py
@@ -77,10 +77,28 @@ def is_valid_dat(infile):
     bool
 
     """
-    with open(infile, "r") as f_in:
+    with open(infile, "rb") as f_in:
         try:
             zlib.decompress(base64.b64decode(f_in.read()))
             is_valid = True
         except:
             is_valid = False
     return is_valid
+
+
+def read_dat(infile):
+    """Read a SIMBAD .dat file
+
+    Parameters
+    ----------
+    infile : str
+       Path to the input pdb file
+
+    Returns
+    -------
+    bool
+
+    """
+    with open(infile, "rb") as f_in:
+        s = zlib.decompress(base64.b64decode(f_in.read()))
+    return s

--- a/simbad/db/__init__.py
+++ b/simbad/db/__init__.py
@@ -3,6 +3,24 @@ import os
 import zlib
 
 
+def _from_dat(fhandle):
+    """Little decompression/decoding function for SIMBAD .dat files"""
+    return zlib.decompress(
+        base64.b64decode(
+            fhandle.read()
+        )
+    )
+
+
+def _to_dat(fhandle):
+    """Little compression/encoding function for SIMBAD .dat files"""
+    return base64.b64encode(
+        zlib.compress(
+            fhandle.read()
+        )
+    )
+
+
 def find_simbad_dat_files(directory):
     """Find all SIMBAD morda files
 
@@ -34,13 +52,7 @@ def convert_dat_to_pdb(infile, outfile):
 
     """
     with open(infile, 'rb') as f_in, open(outfile, 'w') as f_out:
-        f_out.write(
-            zlib.decompress(
-                base64.b64decode(
-                    f_in.read()
-                )
-            )
-        )
+        f_out.write(_from_dat(f_in))
 
 
 def convert_pdb_to_dat(infile, outfile):
@@ -55,13 +67,7 @@ def convert_pdb_to_dat(infile, outfile):
 
     """
     with open(output, "r") as f_in, open(final, "wb") as f_out:
-        f_out.write(
-            base64.b64encode(
-                zlib.compress(
-                    f_in.read()
-                )
-            )
-        )
+        f_out.write(_to_dat(f_in))
 
 
 def is_valid_dat(infile):
@@ -79,7 +85,7 @@ def is_valid_dat(infile):
     """
     with open(infile, "rb") as f_in:
         try:
-            zlib.decompress(base64.b64decode(f_in.read()))
+            _from_dat(f_in)
             is_valid = True
         except:
             is_valid = False
@@ -100,5 +106,5 @@ def read_dat(infile):
 
     """
     with open(infile, "rb") as f_in:
-        s = zlib.decompress(base64.b64decode(f_in.read()))
+        s = _from_dat(f_in)
     return s

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -101,17 +101,18 @@ class AmoreRotationSearch(object):
 
         """
         simbad_dat_files = simbad.db.find_simbad_dat_files(models_dir)
+        n_files = len(simbad_dat_files)
 
-        space_group, _, cell = simbad.util.mtz_util.crystal_data(self.mtz)
+        sg, _, cell = simbad.util.mtz_util.crystal_data(self.mtz)
         cell = " ".join(map(str, cell))
 
-        chunk_size = AmoreRotationSearch.get_chunk_size(len(simbad_dat_files),
-                                                        chunk_size)
-        total_chunk_cycles = AmoreRotationSearch.get_total_chunk_cycles(len(simbad_dat_files),
+        chunk_size = AmoreRotationSearch.get_chunk_size(n_files, chunk_size)
+        total_chunk_cycles = AmoreRotationSearch.get_total_chunk_cycles(n_files,
                                                                         chunk_size)
 
-        tmp_dir = os.path.join(self.work_dir,
-                               "tmp-" + str(uuid.uuid4()))
+        sol_calc = simbad.util.matthews_coef.SolventContent(cell, sg)
+
+        tmp_dir = os.path.join(self.work_dir, "tmp-" + str(uuid.uuid1()))
         if not os.path.isdir(tmp_dir):
             os.makedirs(tmp_dir)
 
@@ -125,10 +126,7 @@ class AmoreRotationSearch(object):
         amore_temp_files = os.path.join(tmp_dir,
                                         os.path.basename(self.amore_exe) + "_*${PID1}")
 
-        sol_calc = simbad.util.matthews_coef.SolventContent(cell,
-                                                            space_group)
-
-        iteration_range = range(0, len(simbad_dat_files), chunk_size)
+        iteration_range = range(0, n_files, chunk_size)
         for cycle, i in enumerate(iteration_range):
             logger.info("Working on chunk %d out of %d", cycle + 1,
                         total_chunk_cycles)

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -112,19 +112,23 @@ class AmoreRotationSearch(object):
 
         sol_calc = simbad.util.matthews_coef.SolventContent(cell, sg)
 
-        tmp_dir = os.path.join(self.work_dir, "tmp-" + str(uuid.uuid1()))
-        if not os.path.isdir(tmp_dir):
-            os.makedirs(tmp_dir)
+        dir_name = "simbad-tmp-" + str(uuid.uuid1())
+        script_log_dir = os.path.join(self.work_dir, dir_name)
+        os.mkdir(script_log_dir)
 
         hklpck0 = self._generate_hklpck0()
-        template_hklpck1 = os.path.join(tmp_dir, "{}.hkl")
-        template_clmn0 = os.path.join(tmp_dir, "{}_spmipch.clmn")
-        template_clmn1 = os.path.join(tmp_dir, "{}.clmn")
-        template_mapout = os.path.join(tmp_dir, "{}_amore_cross.map")
-        template_table1 = os.path.join(tmp_dir, "{}_sfs.tab")
-        template_model = os.path.join(tmp_dir, "{}.pdb")
-        amore_temp_files = os.path.join(tmp_dir,
-                                        os.path.basename(self.amore_exe) + "_*${PID1}")
+
+        template_tmp_dir = os.path.join(os.environ["CCP4_SCR"],
+                                        dir_name + "_{0}")
+        template_hklpck1 = os.path.join(template_tmp_dir, "{0}.hkl")
+        template_clmn0 = os.path.join(template_tmp_dir, "{0}_spmipch.clmn")
+        template_clmn1 = os.path.join(template_tmp_dir, "{0}.clmn")
+        template_mapout = os.path.join(template_tmp_dir, "{0}_amore_cross.map")
+        template_table1 = os.path.join(template_tmp_dir, "{0}_sfs.tab")
+        template_model = os.path.join(template_tmp_dir, "{0}.pdb")
+
+        amore_name = os.path.basename(self.amore_exe) + "_*${PID1}"
+        amore_temp_files = os.path.join(template_tmp_dir, amore_name)
 
         iteration_range = range(0, n_files, chunk_size)
         for cycle, i in enumerate(iteration_range):
@@ -153,41 +157,37 @@ class AmoreRotationSearch(object):
                 mapout = template_mapout.format(name)
 
                 conv_py = "\"from simbad.db import convert_dat_to_pdb; convert_dat_to_pdb('{}', '{}')\""
-                conv_cmd = ["ccp4-python", "-c",
-                            conv_py.format(dat_model, pdb_model)]
+                conv_py = conv_py.format(dat_model, pdb_model)
 
-                rot_stdin = self._write_stdin(
-                    tmp_dir, "rotfun_", name,
-                    self.rotfun_stdin_template.format(
-                        shres=shres, intrad=intrad, pklim=pklim, npic=npic,
-                        step=rotastep
-                    )
+                tab_cmd = [self.amore_exe, "xyzin1", pdb_model, "xyzout1",
+                           pdb_model, "table1", table1]
+                tab_stdin = self.tabfun_stdin_template.format(
+                    x=x, y=y, z=z, a=90, b=90, c=120
                 )
+
                 rot_cmd = [self.amore_exe, 'table1', table1, 'HKLPCK1', hklpck1,
                            'hklpck0', hklpck0, 'clmn1', clmn1, 'clmn0', clmn0,
                            'MAPOUT', mapout]
-
-                tab_stdin = self._write_stdin(
-                    tmp_dir, "tabfun_", name,
-                    self.tabfun_stdin_template.format(
-                        x=x, y=y, z=z, a=90, b=90, c=120
-                    )
+                rot_stdin = self.rotfun_stdin_template.format(
+                    shres=shres, intrad=intrad, pklim=pklim, npic=npic,
+                    step=rotastep
                 )
-                tab_cmd = [self.amore_exe, "xyzin1", pdb_model, "xyzout1",
-                           pdb_model, "table1", table1]
 
-                removables = [clmn0, clmn1, hklpck1, table1, mapout, pdb_model,
-                              amore_temp_files]
+                tmp_dir = template_tmp_dir.format(name)
+                cmd = [
+                    [EXPORT, "CCP4_SCR=" + tmp_dir],
+                    ["mkdir", "-p", "$CCP4_SCR\n"],
+                    ["ccp4-python", "-c", conv_py + "\n"],
+                    tab_cmd + ["<< eof >", os.devnull],
+                    [tab_stdin],
+                    ["eof\n"],
+                    [os.linesep] + rot_cmd + ["<< eof"],
+                    [rot_stdin],
+                    ["eof\n"],
+                    ["rm", "-rf", tmp_dir],
+                ]
                 amore_script = pyjob.misc.make_script(
-                    [
-                        [EXPORT, "CCP4_SCR=" + tmp_dir, os.linesep],
-                        conv_cmd, os.linesep,
-                        tab_cmd + ["<", tab_stdin, "&", os.linesep],
-                        ["export PID1=$!", "&&", "wait", os.linesep],
-                        rot_cmd + ["<", rot_stdin, os.linesep],
-                        ["rm"] + removables
-                    ],
-                    directory=tmp_dir, prefix="amore_", stem=name
+                    cmd, directory=script_log_dir, prefix="amore_", stem=name
                 )
                 amore_log = amore_script.rsplit(".", 1)[0] + '.log'
                 amore_files += [(amore_script, tab_stdin, rot_stdin,
@@ -197,7 +197,7 @@ class AmoreRotationSearch(object):
             if len(amore_files) > 0:
                 logger.info("Running AMORE tab/rot functions")
                 amore_scripts, _, _, amore_logs, dat_models = zip(*amore_files)
-                self.submit_chunk(amore_scripts, tmp_dir, nproc, 'simbad_amore',
+                self.submit_chunk(amore_scripts, script_log_dir, nproc, 'simbad_amore',
                                   submit_qtype, submit_queue, monitor)
 
                 for dat_model, amore_log in zip(dat_models, amore_logs):
@@ -218,7 +218,7 @@ class AmoreRotationSearch(object):
                 logger.critical("No structures to be trialled")
 
         self._search_results = results
-        shutil.rmtree(tmp_dir)
+        shutil.rmtree(script_log_dir)
 
     def summarize(self, csv_file):
         """Summarize the search results
@@ -265,8 +265,7 @@ class AmoreRotationSearch(object):
     def sortfun_stdin_template(self):
         return """TITLE   ** spmi  packing h k l F for crystal**
 SORTFUN RESOL 100.  2.5
-LABI FP={f}  SIGFP={sigf}
-"""
+LABI FP={f}  SIGFP={sigf}"""
 
     @property
     def tabfun_stdin_template(self):
@@ -274,8 +273,7 @@ LABI FP={f}  SIGFP={sigf}
 TABFUN
 CRYSTAL {x} {y} {z} {a} {b} {c} ORTH 1
 MODEL 1 BTARGET 23.5
-SAMPLE 1 RESO 2.5 SHANN 2.5 SCALE 4.0
-"""
+SAMPLE 1 RESO 2.5 SHANN 2.5 SCALE 4.0"""
 
     @property
     def rotfun_stdin_template(self):
@@ -284,8 +282,7 @@ ROTFUN
 GENE 1   RESO 100.0 {shres}  CELL_MODEL 80 75 65
 CLMN CRYSTAL ORTH  1 RESO  20.0  {shres}  SPHERE   {intrad}
 CLMN MODEL 1     RESO  20.0  {shres} SPHERE   {intrad}
-ROTA  CROSS  MODEL 1  PKLIM {pklim}  NPIC {npic} STEP {step}
-"""
+ROTA  CROSS  MODEL 1  PKLIM {pklim}  NPIC {npic} STEP {step}"""
 
     @staticmethod
     def get_chunk_size(total, size):

--- a/simbad/util/pdb_util.py
+++ b/simbad/util/pdb_util.py
@@ -10,18 +10,15 @@ import iotbx.pdb.mining
 import numpy as np
 
 from simbad.chemistry import atomic_composition, periodic_table
+from simbad.db import read_dat
 
 
 class PdbStructure(object):
 
     def __init__(self, pdbin):
         if pdbin.endswith(".dat"):
-            from simbad.db import convert_dat_to_pdb
-            pdbout = tempfile.NamedTemporaryFile(delete=False)
-            pdbout.close()
-            convert_dat_to_pdb(pdbin, pdbout.name)
-            self.pdb_input = iotbx.pdb.pdb_input(file_name=pdbout.name)
-            os.remove(pdbout.name)
+            pdb_str = read_dat(pdbin)
+            self.pdb_input = iotbx.pdb.input(source_info=None, lines=pdb_str)
         else:
             self.pdb_input = iotbx.pdb.pdb_input(file_name=pdbin)
         self.hierarchy = self.pdb_input.construct_hierarchy()


### PR DESCRIPTION
### Added
- `read_dat()` function to convert `.dat` to `str`
- `_to_dat()` and `_from_dat()` functions for easier wrapper functions
### Changed
- `PdbStructure` does not need to convert `.dat` to `.pdb` anymore, convenient wrapper added
- `AmoreRotationSearch` writes all files but the script and log to `$CCP4_SCR`
- `AmoreRotationSearch` stdin files removed to avoid writing of 3 files to disk compared to single script file [big difference on network mounted disks]
### Fixed
- `is_valid_dat()` opened the `.dat` files in non-binary mode
