### PR TITLE
Minor bug fixes and altered default location of tmp dir

### DIFF
--- a/simbad/command_line/__init__.py
+++ b/simbad/command_line/__init__.py
@@ -96,6 +96,8 @@ def _argparse_core_options(p):
                     help='4-letter identifier for job [simb]')
     sg.add_argument('-run_dir', type=str, default=".",
                     help='Directory where the SIMBAD work directory will be created')
+    sg.add_argument('-tmp_dir', type=str,
+                    help='Directory in which to put temporary files from SIMBAD')
     sg.add_argument('-work_dir', type=str,
                     help='Path to the directory where SIMBAD will run (will be created if it doesn\'t exist)')
     sg.add_argument('-webserver_uri',
@@ -242,8 +244,8 @@ def _simbad_contaminant_search(args):
         ed = simbad.util.mtz_util.ExperimentalData(args.mtz)
         ed.output_mtz(temp_mtz)
 
-    rotation_search = AmoreRotationSearch(args.amore_exe, temp_mtz, stem,
-                                          args.max_contaminant_results)
+    rotation_search = AmoreRotationSearch(args.amore_exe, temp_mtz, args.tmp_dir,
+                                          stem, args.max_contaminant_results)
 
     rotation_search.run(args.cont_db, nproc=args.nproc, shres=args.shres,
                         pklim=args.pklim, npic=args.npic,
@@ -304,8 +306,8 @@ def _simbad_morda_search(args):
         ed = simbad.util.mtz_util.ExperimentalData(args.mtz)
         ed.output_mtz(temp_mtz)
 
-    rotation_search = AmoreRotationSearch(args.amore_exe, temp_mtz, stem,
-                                          args.max_morda_results)
+    rotation_search = AmoreRotationSearch(args.amore_exe, temp_mtz, args.tmp_dir,
+                                          stem, args.max_morda_results)
     rotation_search.run(args.morda_db, nproc=args.nproc, shres=args.shres,
                         pklim=args.pklim, npic=args.npic, rotastep=args.rotastep,
                         min_solvent_content=args.min_solvent_content,

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -57,10 +57,11 @@ class AmoreRotationSearch(object):
 
     """
 
-    def __init__(self, amore_exe, mtz, work_dir, max_to_keep=20):
+    def __init__(self, amore_exe, mtz, tmp_dir, work_dir, max_to_keep=20):
         self.amore_exe = amore_exe
         self.max_to_keep = max_to_keep
         self.mtz = mtz
+        self.tmp_dir = tmp_dir
         self.work_dir = work_dir
 
         self._search_results = None
@@ -118,9 +119,11 @@ class AmoreRotationSearch(object):
 
         hklpck0 = self._generate_hklpck0()
 
-        amore_name = os.path.basename(self.amore_exe) + "_*${PID1}"
-        amore_temp_files = os.path.join("$CCP4_SCR", amore_name)
-        template_tmp_dir = os.path.join("$CCP4_SCR", dir_name + "-{0}")
+        if self.tmp_dir:
+            template_tmp_dir = os.path.join(self.tmp_dir, dir_name + "-{0}")
+        else:
+            template_tmp_dir = os.path.join(self.work_dir, 'tmp', dir_name + "-{0}")
+
         template_hklpck1 = os.path.join("$CCP4_SCR", "{0}.hkl")
         template_clmn0 = os.path.join("$CCP4_SCR", "{0}_spmipch.clmn")
         template_clmn1 = os.path.join("$CCP4_SCR", "{0}.clmn")

--- a/simbad/util/pdb_util.py
+++ b/simbad/util/pdb_util.py
@@ -23,7 +23,11 @@ class PdbStructure(object):
         else:
             self.pdb_input = iotbx.pdb.pdb_input(file_name=pdbin)
         self.hierarchy = self.pdb_input.construct_hierarchy()
-        self.crystal_symmetry = self.pdb_input.crystal_symmetry()
+        try:
+            self.crystal_symmetry = self.pdb_input.crystal_symmetry()
+        except AssertionError:
+            logger.debug('Unable to generate crystal symmetry for %s', pdbin)
+            self.crystal_symmetry = None
 
     @property
     def molecular_weight(self):


### PR DESCRIPTION
- Fixed bug with crystal symmetry data, CCTBX was giving an assertion error for certain search models because the cell parameters and space group were considered incompatible

- Changed the default location of the temporary directory from $CCP4_SCR back to work_dir/tmp/ as this immediately crashed when using a large number of cores with a small directory assigned to $CCP4_SCR

- Added in a tmp_dir argument so that $CCP4_SCR can be still be used as a tmp_dir.

- removed reference to amore_name and amore_temp_files as these were unused variables and the files get deleted when the tmp_dir for each job is deleted. 