### PR TITLE
Changes to CCP4_SCR after rotsearch

### DIFF
--- a/simbad/mr/__init__.py
+++ b/simbad/mr/__init__.py
@@ -85,7 +85,7 @@ class MrSubmit(object):
     >>> from simbad.mr import MrSubmit
     >>> MR = MrSubmit('<mtz>', '<mr_program>', '<refine_program>', '<output_dir>', '<enam>')
     >>> MR.submit_jobs('<results>', '<nproc>', '<submit_cluster>', '<submit_qtype>', '<submit_queue>',
-    ...                '<submit_array>', '<submit_max_array>', '<timeout>', '<process_all>', '<monitor>')
+    ...                '<submit_array>', '<submit_max_array>', '<process_all>', '<monitor>')
 
     If a solution is found and process_all is not set, the queued jobs will be terminated.
     """
@@ -295,10 +295,8 @@ class MrSubmit(object):
         ----------
         results : class
             Results from :obj: '_LatticeParameterScore' or :obj: '_AmoreRotationScore'
-        time_out : int, optional
-            Number of seconds for job to timeout [default: 60]
         nproc : int, optional
-            Number of processors to use [default: 2]
+            Number of processors to use [default: 1]
         process_all : bool, optional
             Terminate MR after a success [default: True]
         submit_qtype : str
@@ -373,7 +371,6 @@ class MrSubmit(object):
                     + "cell with a solvent content of at least 30 percent, "\
                     + "therefore MR will use only the first chain"
                 logger.debug(msg, result.pdb_code)
-                logger.debug(msg)
 
             mr_cmd = [
                 "ccp4-python", "-m", self.mr_python_module, "-hklin", self.mtz,

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -119,6 +119,7 @@ class AmoreRotationSearch(object):
 
         hklpck0 = self._generate_hklpck0()
 
+        ccp4_scr = os.environ["CCP4_SCR"]
         if self.tmp_dir:
             template_tmp_dir = os.path.join(self.tmp_dir, dir_name + "-{0}")
         else:
@@ -189,6 +190,7 @@ class AmoreRotationSearch(object):
                     ["eof\n"],
                     ["grep", "-m 1", "SOLUTIONRCD", rot_log, "\n"],
                     ["rm", "-rf", "$CCP4_SCR\n"],
+                    [EXPORT, "CCP4_SCR=" + ccp4_scr],
                 ]
                 amore_script = pyjob.misc.make_script(
                     cmd, directory=script_log_dir, prefix="amore_", stem=name
@@ -223,6 +225,9 @@ class AmoreRotationSearch(object):
 
         self._search_results = results
         shutil.rmtree(script_log_dir)
+
+        if os.path.isdir(os.path.join(self.work_dir, 'tmp')):
+            shutil.rmtree(os.path.join(self.work_dir, 'tmp'))
 
     def summarize(self, csv_file):
         """Summarize the search results

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -120,10 +120,11 @@ class AmoreRotationSearch(object):
         hklpck0 = self._generate_hklpck0()
 
         ccp4_scr = os.environ["CCP4_SCR"]
+        default_tmp_dir = os.path.join(self.work_dir, 'tmp')
         if self.tmp_dir:
             template_tmp_dir = os.path.join(self.tmp_dir, dir_name + "-{0}")
         else:
-            template_tmp_dir = os.path.join(self.work_dir, 'tmp', dir_name + "-{0}")
+            template_tmp_dir = os.path.join(default_tmp_dir, dir_name + "-{0}")
 
         template_hklpck1 = os.path.join("$CCP4_SCR", "{0}.hkl")
         template_clmn0 = os.path.join("$CCP4_SCR", "{0}_spmipch.clmn")
@@ -226,8 +227,8 @@ class AmoreRotationSearch(object):
         self._search_results = results
         shutil.rmtree(script_log_dir)
 
-        if os.path.isdir(os.path.join(self.work_dir, 'tmp')):
-            shutil.rmtree(os.path.join(self.work_dir, 'tmp'))
+        if os.path.isdir(default_tmp_dir):
+            shutil.rmtree(default_tmp_dir)
 
     def summarize(self, csv_file):
         """Summarize the search results


### PR DESCRIPTION
- Added in an export command at the end of the rot script to set CCP4_SCR back to its original path. Was thinking about doing this with a python command at the end amore_search however I seem to recall that this didn't work properly on the cluster. 

- Added a command to remove the tmp_dir made by default. I made the command specific to the default tmp dir as I didn't want to delete the path to an input tmp_dir. 

- Cleaned up some doc strings in mr module. 