### PR TITLE
Fixes to cleanup and phaser alternative spacegroup search

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changed
 - Fixed bug in phaser that fixed a problem in check all/enant spacegroups
 - Changed molrep/phaser to output an hkl, this is needed for changes of basis as a result of all/enant searches
 - Altered the cleanup algorithm to completely remove the mr_search directory and instead rely on the newly created output_files directory
-
+- Altered logging to use enum, closes #81
 
 0.1.11
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,14 @@ Added
 - Check for ``SSL_CERT_FILE`` environmental variable in all command line scripts
 - eRMSD calculation added into the phaser rotation search, default set to 70% ID for now but this may change
 - Added SIMBAD paper to docs
+- Added output_files directory to store all output files
 
 Changed
 ~~~~~~~
+- Fixed bug in phaser that fixed a problem in check all/enant spacegroups
+- Changed molrep/phaser to output an hkl, this is needed for changes of basis as a result of all/enant searches
+- Altered the cleanup algorithm to completely remove the mr_search directory and instead rely on the newly created output_files directory
+
 
 0.1.11
 ------

--- a/simbad/command_line/__init__.py
+++ b/simbad/command_line/__init__.py
@@ -14,6 +14,8 @@ import platform
 import sys
 import time
 
+from enum import Enum
+
 from pyjob import cexec
 from pyjob.platform import EXE_EXT
 from simbad.util import SIMBAD_DIRNAME
@@ -92,18 +94,18 @@ def is_valid_dir(parser, arg):
         parser.error("The directory %s does not exist!" % arg)
 
 
-class LogColors(object):
+class LogColors(Enum):
     """Color container for log messages"""
-    CRITICAL = 31   # red
-    DEBUG = 34      # blue
+    CRITICAL = 31
+    DEBUG = 34
     DEFAULT = 0
-    ERROR = 31      # red
-    WARNING = 33    # yellow
+    ERROR = 31
+    WARNING = 33
 
 
-class LogLevels(object):
+class LogLevels(Enum):
     """Log level container"""
-    CRITICAL = logging.CRITICAL
+
     DEBUG = logging.DEBUG
     ERROR = logging.ERROR
     INFO = logging.INFO
@@ -115,9 +117,9 @@ class LogColorFormatter(logging.Formatter):
     """Formatter for log messages"""
 
     def format(self, record):
-        if record.levelname in vars(LogColors):
-            prefix = '\033[1;{}m'.format(vars(LogColors)[record.levelname])
-            postfix = '\033[{}m'.format(vars(LogColors)["DEFAULT"])
+        if record.levelname in LogColors.__members__:
+            prefix = '\033[1;{}m'.format(LogColors[record.levelname].value)
+            postfix = '\033[{}m'.format(LogColors["DEFAULT"].value)
             record.msg = os.linesep.join([prefix + msg + postfix for msg in str(record.msg).splitlines()])
         return logging.Formatter.format(self, record)
 
@@ -152,7 +154,7 @@ class LogController(object):
     def get_levelname(self, level):
         level_uc = level.upper()
         if LogController.level_valid(level_uc):
-            return vars(LogLevels)[level_uc]
+            return LogLevels[level_uc].value
         else:
             raise ValueError("Please provide a valid log level - %s is not!" % level)
 
@@ -171,7 +173,7 @@ class LogController(object):
 
     @staticmethod
     def level_valid(level):
-        return level in vars(LogLevels)
+        return level in LogLevels.__members__
 
 
 def _argparse_core_options(p):

--- a/simbad/command_line/__init__.py
+++ b/simbad/command_line/__init__.py
@@ -18,6 +18,7 @@ from enum import Enum
 
 from pyjob import cexec
 from pyjob.platform import EXE_EXT
+from simbad.mr.options import MrPrograms, RefPrograms, SGAlternatives
 from simbad.util import SIMBAD_DIRNAME
 
 import simbad.db
@@ -174,13 +175,6 @@ class LogController(object):
         return level in LogLevels.__members__
 
 
-class SGAlternatives(Enum):
-    """Containier for space group alternatives"""
-    all = 'ALL'
-    enant = 'HAND'
-    none = 'NONE'
-
-
 def _argparse_core_options(p):
     """Add core options to an already existing parser"""
     sg = p.add_argument_group('Basic options')
@@ -288,9 +282,9 @@ def _argparse_mr_options(p):
     sg = p.add_argument_group('Molecular Replacement specific options')
     sg.add_argument('-sga', "--sgalternative", default='none', choices=SGAlternatives.__members__.keys(),
                     help='Check alternative space groups')
-    sg.add_argument('-mr_program', type=str, default="molrep", choices=['molrep', 'phaser'],
+    sg.add_argument('-mr_program', type=str, default="molrep", choices=MrPrograms.__members__.keys(),
                     help='Path to the MR program to use.')
-    sg.add_argument('-refine_program', type=str, default="refmac5", choices=['refmac5'],
+    sg.add_argument('-refine_program', type=str, default="refmac5", choices=RefPrograms.__members__.keys(),
                     help='Path to the refinement program to use.')
     sg.add_argument('-refine_cycles', type=int,
                     help='The number of refinement cycles to run [default: 30]')

--- a/simbad/command_line/__init__.py
+++ b/simbad/command_line/__init__.py
@@ -24,8 +24,6 @@ import simbad.db
 import simbad.util.mtz_util
 import simbad.version
 
-from simbad.mr.phaser_mr import SGALTERNATIVES
-
 if os.name != "nt":
     if "SSL_CERT_FILE" not in os.environ:
         os.environ["SSL_CERT_FILE"] = os.path.join(os.environ["CCP4"], 'etc', 'ssl', 'cacert.pem')
@@ -176,6 +174,13 @@ class LogController(object):
         return level in LogLevels.__members__
 
 
+class SGAlternatives(Enum):
+    """Containier for space group alternatives"""
+    all = 'ALL'
+    enant = 'HAND'
+    none = 'NONE'
+
+
 def _argparse_core_options(p):
     """Add core options to an already existing parser"""
     sg = p.add_argument_group('Basic options')
@@ -281,7 +286,7 @@ def _argparse_rot_options(p):
 
 def _argparse_mr_options(p):
     sg = p.add_argument_group('Molecular Replacement specific options')
-    sg.add_argument('-sga', "--sgalternative", choices=SGALTERNATIVES.keys(),
+    sg.add_argument('-sga', "--sgalternative", default='none', choices=SGAlternatives.__members__.keys(),
                     help='Check alternative space groups')
     sg.add_argument('-mr_program', type=str, default="molrep", choices=['molrep', 'phaser'],
                     help='Path to the MR program to use.')

--- a/simbad/command_line/simbad_contaminant.py
+++ b/simbad/command_line/simbad_contaminant.py
@@ -70,10 +70,9 @@ def main():
         logger.info("No results found - contaminant search was unsuccessful")
 
     if args.output_pdb and args.output_mtz:
-        run_dir = os.path.join(args.work_dir, 'cont')
-        csv = os.path.join(run_dir, 'cont_mr.csv')
+        csv = os.path.join(args.work_dir, 'cont', 'cont_mr.csv')
         result = simbad.util.result_by_score_from_csv(csv, 'final_r_free', ascending=True)
-        simbad.util.output_files(run_dir, result, args.output_pdb, args.output_mtz)
+        simbad.util.output_files(args.work_dir, result, args.output_pdb, args.output_mtz)
 
     stopwatch.stop()
     logger.info("All processing completed in %d days, %d hours, %d minutes, and %d seconds",

--- a/simbad/command_line/simbad_full.py
+++ b/simbad/command_line/simbad_full.py
@@ -141,8 +141,7 @@ def main():
     if len(all_results) >= 1:
         sorted_results = sorted(all_results.iteritems(), key=lambda (k, v): (v[1], k))
         result = sorted_results[0][1]
-        run_dir = os.path.join(args.work_dir, sorted_results[0][0])
-        simbad.util.output_files(run_dir, result, args.output_pdb, args.output_mtz)
+        simbad.util.output_files(args.work_dir, result, args.output_pdb, args.output_mtz)
 
     stopwatch.stop()
     logger.info("All processing completed in %d days, %d hours, %d minutes, and %d seconds",

--- a/simbad/command_line/simbad_lattice.py
+++ b/simbad/command_line/simbad_lattice.py
@@ -82,11 +82,10 @@ def main():
         display_summary = True
 
     if args.output_pdb and args.output_mtz:
-        run_dir = os.path.join(args.work_dir, 'latt')
-        csv = os.path.join(run_dir, 'lattice_mr.csv')
+        csv = os.path.join(args.work_dir, 'latt', 'lattice_mr.csv')
         if os.path.exists(csv):
             result = simbad.util.result_by_score_from_csv(csv, 'final_r_free', ascending=True)
-            simbad.util.output_files(run_dir, result, args.output_pdb, args.output_mtz)
+            simbad.util.output_files(args.work_dir, result, args.output_pdb, args.output_mtz)
 
     stopwatch.stop()
     logger.info("All processing completed in %d days, %d hours, %d minutes, and %d seconds",

--- a/simbad/command_line/simbad_main.py
+++ b/simbad/command_line/simbad_main.py
@@ -119,8 +119,7 @@ def main():
     if len(all_results) >= 1:
         sorted_results = sorted(all_results.iteritems(), key=lambda (k, v): (v[1], k))
         result = sorted_results[0][1]
-        run_dir = os.path.join(args.work_dir, sorted_results[0][0])
-        simbad.util.output_files(run_dir, result, args.output_pdb, args.output_mtz)
+        simbad.util.output_files(args.work_dir, result, args.output_pdb, args.output_mtz)
 
     stopwatch.stop()
     logger.info("All processing completed in %d days, %d hours, %d minutes, and %d seconds",

--- a/simbad/command_line/simbad_morda.py
+++ b/simbad/command_line/simbad_morda.py
@@ -70,10 +70,9 @@ def main():
         logger.info("No results found - full search was unsuccessful")
 
     if args.output_pdb and args.output_mtz:
-        run_dir = os.path.join(args.work_dir, 'morda')
-        csv = os.path.join(run_dir, 'morda_mr.csv')
+        csv = os.path.join(args.work_dir, 'morda', 'morda_mr.csv')
         result = simbad.util.result_by_score_from_csv(csv, 'final_r_free', ascending=True)
-        simbad.util.output_files(run_dir, result, args.output_pdb, args.output_mtz)
+        simbad.util.output_files(args.work_dir, result, args.output_pdb, args.output_mtz)
 
     stopwatch.stop()
     logger.info("All processing completed in %d days, %d hours, %d minutes, and %d seconds",

--- a/simbad/mr/__init__.py
+++ b/simbad/mr/__init__.py
@@ -337,6 +337,8 @@ class MrSubmit(object):
                                       '{0}_mr.log'.format(result.pdb_code))
             mr_pdbout = os.path.join(mr_workdir,
                                      '{0}_mr_output.pdb'.format(result.pdb_code))
+            mr_hklout = os.path.join(mr_workdir,
+                                     '{0}_mr_output.mtz'.format(result.pdb_code))
 
             ref_workdir = os.path.join(mr_workdir, 'refine')
             ref_hklout = os.path.join(ref_workdir,
@@ -387,7 +389,7 @@ class MrSubmit(object):
 
             solvent_content = sol_cont.calculate_from_struct(pdb_struct)
             if solvent_content > 30:
-                n_copies = 1
+                solvent_content, n_copies = mat_prob.calculate_content_ncopies_from_struct(pdb_struct)
             else:
                 pdb_struct.keep_first_chain_only()
                 pdb_struct.save(mr_pdbin)
@@ -398,14 +400,14 @@ class MrSubmit(object):
                 logger.debug(msg, result.pdb_code)
 
             mr_cmd = [
-                CMD_PREFIX, "ccp4-python", "-m", self.mr_python_module, "-hklin", self.mtz,
-                "-pdbin", mr_pdbin, "-pdbout", mr_pdbout, "-logfile", mr_logfile,
-                "-work_dir", mr_workdir, "-nmol", n_copies, "-sgalternative", self.sgalternative
+                CMD_PREFIX, "ccp4-python", "-m", self.mr_python_module, "-hklin", self.mtz, "-hklout", mr_hklout,
+                "-pdbin", mr_pdbin, "-pdbout", mr_pdbout, "-logfile", mr_logfile, "-work_dir", mr_workdir,
+                "-nmol", n_copies, "-sgalternative", self.sgalternative
             ]
 
             ref_cmd = [
                 CMD_PREFIX, "ccp4-python", "-m", self.refine_python_module, "-pdbin", mr_pdbout,
-                "-pdbout", ref_pdbout,  "-hklin", self.mtz, "-hklout", ref_hklout, "-logfile", ref_logfile,
+                "-pdbout", ref_pdbout,  "-hklin", mr_hklout, "-hklout", ref_hklout, "-logfile", ref_logfile,
                 "-work_dir", ref_workdir, "-refinement_type", self.refine_type, "-ncyc", self.refine_cycles
             ]
 

--- a/simbad/mr/__init__.py
+++ b/simbad/mr/__init__.py
@@ -14,6 +14,7 @@ from pyjob import Job
 from pyjob.misc import make_script, tmp_file
 
 from simbad.mr import anomalous_util
+from simbad.mr.options import MrPrograms, RefPrograms
 from simbad.parsers import molrep_parser
 from simbad.parsers import phaser_parser
 from simbad.parsers import refmac_parser
@@ -30,10 +31,6 @@ logger = logging.getLogger(__name__)
 
 EXPORT = "SET" if os.name == "nt" else "export"
 CMD_PREFIX = "call" if os.name == "nt" else ""
-
-# Make clear which binaries we currently support
-KNOWN_MR_PROGRAMS = ["molrep", "phaser"]
-KNOWN_REF_PROGRAMS = ["refmac5"]
 
 
 class MrSubmit(object):
@@ -178,10 +175,7 @@ class MrSubmit(object):
     @property
     def mr_python_module(self):
         """The MR python module"""
-        if self.mr_program == "molrep":
-            return "simbad.mr.molrep_mr"
-        elif self.mr_program == "phaser":
-            return "simbad.mr.phaser_mr"
+        return MrPrograms[self.mr_program].value
 
     @property
     def mr_program(self):
@@ -191,7 +185,7 @@ class MrSubmit(object):
     @mr_program.setter
     def mr_program(self, mr_program):
         """Define the molecular replacement program to use"""
-        if mr_program.lower() in KNOWN_MR_PROGRAMS:
+        if mr_program.lower() in MrPrograms.__members__:
             self._mr_program = mr_program.lower()
         else:
             msg = "Unknown MR program!"
@@ -200,8 +194,7 @@ class MrSubmit(object):
     @property
     def refine_python_module(self):
         """The Refinement python module"""
-        if self.refine_program == "refmac5":
-            return "simbad.mr.refmac_refine"
+        return RefPrograms[self.refine_program].value
 
     @property
     def refine_program(self):
@@ -211,7 +204,7 @@ class MrSubmit(object):
     @refine_program.setter
     def refine_program(self, refine_program):
         """Define the refinement program to use"""
-        if refine_program.lower() in KNOWN_REF_PROGRAMS:
+        if refine_program.lower() in RefPrograms.__members__:
             self._refine_program = refine_program
         else:
             msg = "Unknown Refinement program!"

--- a/simbad/mr/__init__.py
+++ b/simbad/mr/__init__.py
@@ -10,7 +10,7 @@ import logging
 import numpy
 import os
 
-from pyjob import Job, cexec
+from pyjob import Job
 from pyjob.misc import make_script, tmp_file
 
 from simbad.mr import anomalous_util

--- a/simbad/mr/molrep_mr.py
+++ b/simbad/mr/molrep_mr.py
@@ -9,6 +9,7 @@ import os
 import operator
 import shutil
 
+from simbad.mr.phaser_mr import SGALTERNATIVES
 from simbad.util import mtz_util
 
 from pyjob import cexec
@@ -78,7 +79,6 @@ class Molrep(object):
     def __init__(self, hklin, hklout, logfile, nmol, pdbin, pdbout, sgalternative, space_group, work_dir):
 
         self._hklin = None
-        self._hklout = None
         self._logfile = None
         self._nmol = None
         self._pdbin = None
@@ -282,16 +282,6 @@ class Molrep(object):
     def hklin(self, hklin):
         """Define the input hkl file"""
         self._hklin = hklin
-
-    @property
-    def hklout(self):
-        """The output hkl file"""
-        return self._hklout
-
-    @ hklout.setter
-    def hklout(self, hklout):
-        """Define the output hkl file"""
-        self._hklout = hklout
 
     @property
     def logfile(self):
@@ -528,7 +518,7 @@ if __name__ == '__main__':
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', choices=['all', 'enant', 'None'],
+    group.add_argument('-sgalternative', choices=SGALTERNATIVES.keys(),
                        help="Try alternative space groups")
     group.add_argument('-space_group', type=str,
                        help="The input space group")

--- a/simbad/mr/molrep_mr.py
+++ b/simbad/mr/molrep_mr.py
@@ -67,7 +67,7 @@ class Molrep(object):
     Example
     -------
     >>> from simbad.mr.molrep_mr import Molrep
-    >>> molrep = Molrep('<hklin>', '<logfile>', '<nmol>', '<pdbin>', '<pdbout>', '<sgalternative>',
+    >>> molrep = Molrep('<hklin>', '<hklout>', '<logfile>', '<nmol>', '<pdbin>', '<pdbout>', '<sgalternative>',
     >>>                 '<space_group>', '<work_dir>')
     >>> molrep.run()
 
@@ -75,9 +75,10 @@ class Molrep(object):
     logfile can be specified.
     """
 
-    def __init__(self, hklin, logfile, nmol, pdbin, pdbout, sgalternative, space_group, work_dir):
+    def __init__(self, hklin, hklout, logfile, nmol, pdbin, pdbout, sgalternative, space_group, work_dir):
 
         self._hklin = None
+        self._hklout = None
         self._logfile = None
         self._nmol = None
         self._pdbin = None
@@ -87,6 +88,7 @@ class Molrep(object):
         self._space_group = None
 
         self.hklin = hklin
+        self.hklout = hklout
         self.logfile = logfile
         self.nmol = nmol
         self.pdbin = pdbin
@@ -282,6 +284,16 @@ class Molrep(object):
         self._hklin = hklin
 
     @property
+    def hklout(self):
+        """The output hkl file"""
+        return self._hklout
+
+    @ hklout.setter
+    def hklout(self, hklout):
+        """Define the output hkl file"""
+        self._hklout = hklout
+
+    @property
     def logfile(self):
         """The logfile output"""
         return self._logfile
@@ -373,7 +385,7 @@ class Molrep(object):
             os.makedirs(self.work_dir)
             os.chdir(self.work_dir)
 
-        # Copy hklin and pdbin to working dire for efficient running of MOLREP
+        # Copy hklin and pdbin to working dir for efficient running of MOLREP
         hklin = os.path.join(self.work_dir, os.path.basename(self.hklin))
         shutil.copyfile(self.hklin, hklin)
         pdbin = os.path.join(self.work_dir, os.path.basename(self.pdbin))
@@ -426,11 +438,13 @@ class Molrep(object):
                                 os.path.join(self.work_dir, 'molrep_out_{0}.pdb'.format(alt_sg_code)))
             self.evaluate_results(contrasts)
 
-            
         else:
             # Move output pdb to specified name
             if os.path.isfile(os.path.join(self.work_dir, 'molrep_out_{0}.pdb'.format(self.space_group))):
                 shutil.move(os.path.join(self.work_dir, 'molrep_out_{0}.pdb'.format(self.space_group)), self.pdbout)
+            # Move output hkl to specified name
+            if os.path.isfile(self.hklin):
+                shutil.copy(self.hklin, self.hklout)
             # Move log file to specified name
             if os.path.isfile(os.path.join(self.work_dir, 'molrep_out_{0}.log'.format(self.space_group))):
                 shutil.move(os.path.join(self.work_dir, 'molrep_out_{0}.log'.format(self.space_group)), self.logfile)
@@ -469,7 +483,7 @@ class Molrep(object):
 
         ed = mtz_util.ExperimentalData(self.hklin)
         ed.change_space_group(top_sg_code)
-        ed.output_mtz(self.hklout)
+        ed.output_mtz(self.hklin)
     
     @staticmethod
     def molrep(key, logfile):
@@ -504,6 +518,8 @@ if __name__ == '__main__':
     group = parser.add_argument_group()
     group.add_argument('-hklin', type=str,
                        help="Path the input hkl file")
+    group.add_argument('-hklout', type=str,
+                       help="Path the output hkl file")
     group.add_argument('-logfile', type=str,
                        help="Path to the ouput log file")
     group.add_argument('-nmol', type=int,
@@ -512,14 +528,14 @@ if __name__ == '__main__':
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', default=None,
-                       help="Try alternative space groups <all/enant>")
+    group.add_argument('-sgalternative', choices=['all', 'enant', 'None'],
+                       help="Try alternative space groups")
     group.add_argument('-space_group', type=str,
                        help="The input space group")
     group.add_argument('-work_dir', type=str,
                        help="Path to the working directory")
     args = parser.parse_args()
     
-    molrep = Molrep(args.hklin, args.logfile, args.nmol, args.pdbin, args.pdbout, args.sgalternative,
+    molrep = Molrep(args.hklin, args.hklout, args.logfile, args.nmol, args.pdbin, args.pdbout, args.sgalternative,
                     args.space_group, args.work_dir)
     molrep.run()

--- a/simbad/mr/molrep_mr.py
+++ b/simbad/mr/molrep_mr.py
@@ -9,7 +9,7 @@ import os
 import operator
 import shutil
 
-from simbad.command_line import SGAlternatives
+from simbad.mr.options import SGAlternatives
 from simbad.util import mtz_util
 
 from pyjob import cexec

--- a/simbad/mr/molrep_mr.py
+++ b/simbad/mr/molrep_mr.py
@@ -9,7 +9,7 @@ import os
 import operator
 import shutil
 
-from simbad.mr.phaser_mr import SGALTERNATIVES
+from simbad.command_line import SGAlternatives
 from simbad.util import mtz_util
 
 from pyjob import cexec
@@ -518,7 +518,7 @@ if __name__ == '__main__':
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', choices=SGALTERNATIVES.keys(),
+    group.add_argument('-sgalternative', choices=SGAlternatives.__members__.keys(),
                        help="Try alternative space groups")
     group.add_argument('-space_group', type=str,
                        help="The input space group")

--- a/simbad/mr/options.py
+++ b/simbad/mr/options.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class MrPrograms(Enum):
+    """Container for molecular replacement programs"""
+    molrep = 'simbad.mr.molrep_mr'
+    phaser = 'simbad.mr.phaser_mr'
+
+
+class RefPrograms(Enum):
+    """Container for refinement programs"""
+    refmac5 = 'simbad.mr.refmac_refine'
+
+
+class SGAlternatives(Enum):
+    """Container for space group alternatives"""
+    all = 'ALL'
+    enant = 'HAND'
+    none = 'NONE'

--- a/simbad/mr/phaser_mr.py
+++ b/simbad/mr/phaser_mr.py
@@ -13,6 +13,7 @@ from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
 SGALTERNATIVES = {
     'all': 'ALL',
     'enant': 'HAND',
+    'None': 'NONE'
 }
 
 

--- a/simbad/mr/phaser_mr.py
+++ b/simbad/mr/phaser_mr.py
@@ -10,6 +10,7 @@ import shutil
 
 from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
 
+
 class Phaser(object):
     """Class to run PHASER
 
@@ -46,21 +47,23 @@ class Phaser(object):
     Examples
     --------
     >>> from simbad.mr.phaser_mr import Phaser
-    >>> phaser = Phaser('<hklin>', '<f>', '<i>', '<logfile>', '<nmol>', '<pdbin>', '<pdbout>', '<sgalternative>',
-    >>>                 '<sigf>', '<sigi>', '<solvent>', '<timeout>', '<workdir>', '<autohigh>', '<hires>')
+    >>> phaser = Phaser('<hklin>', '<hklout>', '<f>', '<i>', '<logfile>', '<nmol>', '<pdbin>', '<pdbout>',
+    >>>                 '<sgalternative>', '<sigf>', '<sigi>', '<solvent>', '<timeout>', '<workdir>', '<autohigh>',
+    >>>                 '<hires>')
     >>> phaser.run()
 
     Files relating to the PHASER run will be contained within the work_dir however the location of the output hkl, pdb
     and logfile can be specified.
     """
 
-    def __init__(self, hklin, f, i, logfile, nmol, pdbin, pdbout, sgalternative, sigf, sigi, solvent, timeout,
+    def __init__(self, hklin, hklout, f, i, logfile, nmol, pdbin, pdbout, sgalternative, sigf, sigi, solvent, timeout,
                  work_dir, hires, autohigh):
         self._f = None
         self._i = None
         self._autohigh = None
         self._hires = None
         self._hklin = None
+        self._hklout = None
         self._logfile = None
         self._nmol = None
         self._pdbin = None
@@ -78,6 +81,7 @@ class Phaser(object):
         self.autohigh = autohigh
         self.hires = hires
         self.hklin = hklin
+        self.hklout = hklout
         self.logfile = logfile
         self.nmol = nmol
         self.pdbin = pdbin
@@ -137,6 +141,16 @@ class Phaser(object):
     def hklin(self, hklin):
         """Define the input hkl file"""
         self._hklin = hklin
+
+    @property
+    def hklout(self):
+        """The output hkl file"""
+        return self._hklout
+
+    @ hklout.setter
+    def hklout(self, hklout):
+        """Define the output hkl file"""
+        self._hklout = hklout
 
     @property
     def logfile(self):
@@ -238,7 +252,7 @@ class Phaser(object):
         file
             Output log file
         """
-        
+
         # Make a note of the current working directory
         current_work_dir = os.getcwd()
 
@@ -283,19 +297,27 @@ class Phaser(object):
             i.setJOBS(1)
             i.setREFL_DATA(r.getREFL_DATA())
             i.setROOT("phaser_mr_output")
-            i.addENSE_PDB_RMS("PDB", pdbin, 0.6)
+            i.addENSE_PDB_RMS("PDB", pdbin, 1.2)
             i.setCOMP_BY("SOLVENT")
             i.setCOMP_PERC(self.solvent)
             i.addSEAR_ENSE_NUM('PDB', self.nmol)
+            if self.sgalternative == "all":
+                i.setSGAL_SELE("ALL")
+            elif self.sgalternative == "enant":
+                i.setSGAL_SELE("HAND")
+            else:
+                i.setSGAL_SELE("NONE")
             if self.timeout != 0:
                 i.setKILL_TIME(self.timeout)
             i.setMUTE(True)
             del(r)
             r = runMR_AUTO(i)
-            shutil.move(r.getTopPdbFile(), self.pdbout)
 
             with open(self.logfile, 'w') as f:
                 f.write(r.summary())
+
+            shutil.move(r.getTopPdbFile(), self.pdbout)
+            shutil.move(r.getTopMtzFile(), self.hklout)
 
         # Return to original working directory
         os.chdir(current_work_dir)
@@ -319,6 +341,8 @@ if __name__ == "__main__":
                        help="The high resolution limit of data used to find/refine this solution")
     group.add_argument('-hklin', type=str,
                        help="Path the input hkl file")
+    group.add_argument('-hklout', type=str,
+                       help="Path the output hkl file")
     group.add_argument('-f', type=str,
                        help="The column label for F")
     group.add_argument('-i', type=str,
@@ -331,8 +355,8 @@ if __name__ == "__main__":
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', default=None,
-                       help="Try alternative space groups <all/enant>")
+    group.add_argument('-sgalternative', choices=['all', 'enant', 'None'],
+                       help="Try alternative space groups")
     group.add_argument('-sigf', type=str,
                        help="The column label for SIGF")
     group.add_argument('-sigi', type=str,
@@ -345,7 +369,7 @@ if __name__ == "__main__":
                        help="Path to the working directory")
     args = parser.parse_args()
 
-    phaser = Phaser(args.hklin, args.f, args.i, args.logfile, args.nmol, args.pdbin, args.pdbout,
+    phaser = Phaser(args.hklin, args.hklout, args.f, args.i, args.logfile, args.nmol, args.pdbin, args.pdbout,
                     args.sgalternative, args.sigf, args.sigi, args.solvent, args.timeout, args.work_dir,
                     args.hires, args.autohigh)
     phaser.run()

--- a/simbad/mr/phaser_mr.py
+++ b/simbad/mr/phaser_mr.py
@@ -8,7 +8,7 @@ __version__ = "1.0"
 import os
 import shutil
 
-from simbad.command_line import SGAlternatives
+from simbad.mr.options import SGAlternatives
 
 from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
 

--- a/simbad/mr/phaser_mr.py
+++ b/simbad/mr/phaser_mr.py
@@ -8,13 +8,9 @@ __version__ = "1.0"
 import os
 import shutil
 
-from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
+from simbad.command_line import SGAlternatives
 
-SGALTERNATIVES = {
-    'all': 'ALL',
-    'enant': 'HAND',
-    'None': 'NONE'
-}
+from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
 
 
 class Phaser(object):
@@ -340,7 +336,7 @@ if __name__ == "__main__":
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', choices=SGALTERNATIVES.keys(),
+    group.add_argument('-sgalternative', choices=SGAlternatives.__members__.keys(),
                        help="Try alternative space groups")
     group.add_argument('-sigf', type=str,
                        help="The column label for SIGF")

--- a/simbad/mr/phaser_mr.py
+++ b/simbad/mr/phaser_mr.py
@@ -10,6 +10,11 @@ import shutil
 
 from phaser import InputMR_DAT, runMR_DAT, InputMR_AUTO, runMR_AUTO
 
+SGALTERNATIVES = {
+    'all': 'ALL',
+    'enant': 'HAND',
+}
+
 
 class Phaser(object):
     """Class to run PHASER
@@ -63,7 +68,6 @@ class Phaser(object):
         self._autohigh = None
         self._hires = None
         self._hklin = None
-        self._hklout = None
         self._logfile = None
         self._nmol = None
         self._pdbin = None
@@ -141,16 +145,6 @@ class Phaser(object):
     def hklin(self, hklin):
         """Define the input hkl file"""
         self._hklin = hklin
-
-    @property
-    def hklout(self):
-        """The output hkl file"""
-        return self._hklout
-
-    @ hklout.setter
-    def hklout(self, hklout):
-        """Define the output hkl file"""
-        self._hklout = hklout
 
     @property
     def logfile(self):
@@ -283,12 +277,7 @@ class Phaser(object):
         else:
             msg = "No flags for intensities or amplitudes have been provided"
             raise RuntimeError(msg)
-        if self.sgalternative == "all":
-            i.setSGAL_SELE("ALL")
-        elif self.sgalternative == "enant":
-            i.setSGAL_SELE("HAND")
-        else:
-            i.setSGAL_SELE("NONE")
+        i.setSGAL_SELE(SGALTERNATIVES.get(self.sgalternative, 'NONE'))
         i.setMUTE(True)
         r = runMR_DAT(i)
 
@@ -301,12 +290,7 @@ class Phaser(object):
             i.setCOMP_BY("SOLVENT")
             i.setCOMP_PERC(self.solvent)
             i.addSEAR_ENSE_NUM('PDB', self.nmol)
-            if self.sgalternative == "all":
-                i.setSGAL_SELE("ALL")
-            elif self.sgalternative == "enant":
-                i.setSGAL_SELE("HAND")
-            else:
-                i.setSGAL_SELE("NONE")
+            i.setSGAL_SELE(SGALTERNATIVES.get(self.sgalternative, 'NONE'))
             if self.timeout != 0:
                 i.setKILL_TIME(self.timeout)
             i.setMUTE(True)
@@ -355,7 +339,7 @@ if __name__ == "__main__":
                        help="Path to the input pdb file")
     group.add_argument('-pdbout', type=str,
                        help="Path to the output pdb file")
-    group.add_argument('-sgalternative', choices=['all', 'enant', 'None'],
+    group.add_argument('-sgalternative', choices=SGALTERNATIVES.keys(),
                        help="Try alternative space groups")
     group.add_argument('-sigf', type=str,
                        help="The column label for SIGF")

--- a/simbad/util/__init__.py
+++ b/simbad/util/__init__.py
@@ -4,7 +4,6 @@ __author__ = "Adam Simpkin, Felix Simkovic & Jens Thomas"
 __date__ = "05 May 2017"
 __version__ = "1.0"
 
-import glob
 import logging
 import os
 import pandas as pd
@@ -22,9 +21,9 @@ logger = logging.getLogger(__name__)
 def output_files(run_dir, result, output_pdb, output_mtz):
     """Return output pdb/mtz from best result in result obj"""
     pdb_code = result[0]
-    stem = os.path.join(run_dir, 'mr_search', pdb_code, 'mr', '*', 'refine')
-    input_pdb = glob.glob(os.path.join(stem, '{0}_refinement_output.pdb'.format(pdb_code)))[0]
-    input_mtz = glob.glob(os.path.join(stem, '{0}_refinement_output.mtz'.format(pdb_code)))[0]
+    stem = os.path.join(run_dir, 'output_files', pdb_code)
+    input_pdb = os.path.join(stem, '{0}_refinement_output.pdb'.format(pdb_code))
+    input_mtz = os.path.join(stem, '{0}_refinement_output.mtz'.format(pdb_code))
     shutil.copyfile(input_pdb, output_pdb)
     shutil.copyfile(input_mtz, output_mtz)
 

--- a/simbad/util/pyrvapi_results.py
+++ b/simbad/util/pyrvapi_results.py
@@ -35,6 +35,7 @@ class RvapiMetadata(object):
         self.__dict__.update({"nResults": self.n_results})
         return json.dumps(self.__dict__)
 
+
 class SimbadOutput(object):
     """Class to display the output of SIMBAD
 
@@ -387,21 +388,13 @@ class SimbadOutput(object):
             for i in range(0, results_to_display):
                 try:
                     pdb_code = df.loc[i][0]
-                    mr_program = list(df)[1][0:6]
-                    mr_workdir = os.path.join(
-                        self.work_dir, 'latt', 'mr_search', pdb_code, 'mr', mr_program)
-                    mr_log = os.path.join(
-                        mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(
-                        mr_workdir, 'refine', '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_fofcwt.map'.format(pdb_code))
+                    mr_workdir = os.path.join(self.work_dir, 'output_files')
+                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
                     pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
                         [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
@@ -493,21 +486,13 @@ class SimbadOutput(object):
             for i in range(0, results_to_display):
                 try:
                     pdb_code = df.loc[i][0]
-                    mr_program = list(df)[1][0:6]
-                    mr_workdir = os.path.join(
-                        self.work_dir, 'cont', 'mr_search', pdb_code, 'mr', mr_program)
-                    mr_log = os.path.join(
-                        mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(
-                        mr_workdir, 'refine', '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_fofcwt.map'.format(pdb_code))
+                    mr_workdir = os.path.join(self.work_dir, 'output_files')
+                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
                     pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
                         [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
@@ -599,21 +584,13 @@ class SimbadOutput(object):
             for i in range(0, results_to_display):
                 try:
                     pdb_code = df.loc[i][0]
-                    mr_program = list(df)[1][0:6]
-                    mr_workdir = os.path.join(
-                        self.work_dir, 'morda', 'mr_search', pdb_code, 'mr', mr_program)
-                    mr_log = os.path.join(
-                        mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(
-                        mr_workdir, 'refine', '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(
-                        mr_workdir, 'refine', '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(
-                        mr_workdir, 'refine', '{0}_refmac_fofcwt.map'.format(pdb_code))
+                    mr_workdir = os.path.join(self.work_dir, 'output_files')
+                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
                     pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
                         [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
@@ -678,37 +655,28 @@ class SimbadOutput(object):
                 pdb_code = self.lattice_df.loc[0][0]
                 r_fact = self.lattice_df['final_r_fact'][0]
                 r_free = self.lattice_df['final_r_free'][0]
-                mr_program = list(self.lattice_df)[1][0:6]
                 source = "latt"
             elif contaminant_score <= lattice_score and contaminant_score <= morda_db_score:
                 pdb_code = self.contaminant_df.loc[0][0]
                 r_fact = self.contaminant_df['final_r_fact'][0]
                 r_free = self.contaminant_df['final_r_free'][0]
-                mr_program = list(self.contaminant_df)[1][0:6]
                 source = "cont"
             elif morda_db_score <= lattice_score and morda_db_score <= contaminant_score:
                 pdb_code = self.morda_db_df.loc[0][0]
                 r_fact = self.morda_db_df['final_r_fact'][0]
                 r_free = self.morda_db_df['final_r_free'][0]
-                mr_program = list(self.morda_db_df)[1][0:6]
                 source = "morda"
             else:
                 logger.debug('Unexpected result')
                 return
 
-            mr_workdir = os.path.join(self.work_dir, source, 'mr_search',
-                                      pdb_code, 'mr', mr_program)
+            mr_workdir = os.path.join(self.work_dir, 'output_files', pdb_code)
             mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
-            ref_log = os.path.join(mr_workdir, 'refine',
-                                   '{0}_ref.log'.format(pdb_code))
-            ref_pdb = os.path.join(
-                mr_workdir, 'refine', '{0}_refinement_output.pdb'.format(pdb_code))
-            ref_map = os.path.join(mr_workdir, 'refine',
-                                   '{0}_refmac_2fofcwt.map'.format(pdb_code))
-            ref_mtz = os.path.join(mr_workdir, 'refine',
-                                   '{0}_refinement_output.mtz'.format(pdb_code))
-            diff_map = os.path.join(mr_workdir, 'refine',
-                                    '{0}_refmac_fofcwt.map'.format(pdb_code))
+            ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+            ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+            ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+            ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+            diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
             msg = 'The best search model found by SIMBAD was {0}. \
                    This gave an R/Rfact of {1:.3f} and an R/Rfree of {2:.3f}. \

--- a/simbad/util/pyrvapi_results.py
+++ b/simbad/util/pyrvapi_results.py
@@ -149,7 +149,7 @@ class SimbadOutput(object):
                 self.jsrview_dir = os.path.join(work_dir, SIMBAD_PYRVAPI_SHAREDIR)
                 os.mkdir(self.jsrview_dir)
                 wintitle = "SIMBAD Results"
-                
+
                 if ccp4i2_xml:
                     self.init_from_ccp4i2_xml(ccp4i2_xml, self.jsrview_dir, share_jsrview, wintitle)
                 else:
@@ -173,28 +173,28 @@ class SimbadOutput(object):
                 self.create_log_tab(logfile)
 
         pyrvapi.rvapi_flush()
-        
+
     def init_from_ccp4i2_xml(self, ccp4i2_xml, pyrvapi_dir, share_jsrview, wintitle):
         """This code is largely stolen from Andrew Lebedev"""
-        
+
         #// Document modes
         #define RVAPI_MODE_Silent  0x00100000
         #define RVAPI_MODE_Html    0x00000001
         #define RVAPI_MODE_Xmli2   0x00000002
-    
+
         mode = pyrvapi.RVAPI_MODE_Html | bool(ccp4i2_xml)* pyrvapi.RVAPI_MODE_Xmli2
-    
+
         #// Document layouts
         #define RVAPI_LAYOUT_Header   0x00000001
         #define RVAPI_LAYOUT_Toolbar  0x00000002
         #define RVAPI_LAYOUT_Tabs     0x00000004
         #define RVAPI_LAYOUT_Full     0x00000007
-    
+
         xml_relpath =  os.path.relpath(ccp4i2_xml, pyrvapi_dir) if ccp4i2_xml else None
         docid = 'TestRun'
         layout = pyrvapi.RVAPI_LAYOUT_Full
         html = 'index.html'
-        
+
         pyrvapi.rvapi_init_document(
           docid,             # const char * docId      // mandatory
           pyrvapi_dir,         # const char * outDir     // mandatory
@@ -386,19 +386,19 @@ class SimbadOutput(object):
             self.lattice_df = df
 
             for i in range(0, results_to_display):
-                try:
-                    pdb_code = df.loc[i][0]
-                    mr_workdir = os.path.join(self.work_dir, 'output_files')
-                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
+                pdb_code = df.loc[i][0]
+                mr_workdir = os.path.join(self.work_dir, 'output_files')
+                mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
-                    pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
-                        [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
-                    ))
+                pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
+                    [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
+                ))
+                try:
                     self.store_entry_in_rvapi_meta(
                         i + 1, "latt", pdb_code, pdb, mtz, map_, dmap, False)
                     self.output_result_files(
@@ -484,19 +484,19 @@ class SimbadOutput(object):
                 logfile_sec, section_title, tab, 0, 0, 1, 1, False)
 
             for i in range(0, results_to_display):
-                try:
-                    pdb_code = df.loc[i][0]
-                    mr_workdir = os.path.join(self.work_dir, 'output_files')
-                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
+                pdb_code = df.loc[i][0]
+                mr_workdir = os.path.join(self.work_dir, 'output_files')
+                mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
-                    pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
-                        [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
-                    ))
+                pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
+                    [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
+                ))
+                try:
                     self.store_entry_in_rvapi_meta(
                         i + 1, "cont", pdb_code, pdb, mtz, map_, dmap, False)
                     self.output_result_files(
@@ -582,19 +582,19 @@ class SimbadOutput(object):
                 logfile_sec, section_title, tab, 0, 0, 1, 1, False)
 
             for i in range(0, results_to_display):
-                try:
-                    pdb_code = df.loc[i][0]
-                    mr_workdir = os.path.join(self.work_dir, 'output_files')
-                    mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
-                    ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
-                    ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
-                    ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
-                    ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
-                    diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
+                pdb_code = df.loc[i][0]
+                mr_workdir = os.path.join(self.work_dir, 'output_files')
+                mr_log = os.path.join(mr_workdir, '{0}_mr.log'.format(pdb_code))
+                ref_pdb = os.path.join(mr_workdir, '{0}_refinement_output.pdb'.format(pdb_code))
+                ref_mtz = os.path.join(mr_workdir, '{0}_refinement_output.mtz'.format(pdb_code))
+                ref_log = os.path.join(mr_workdir, '{0}_ref.log'.format(pdb_code))
+                ref_map = os.path.join(mr_workdir, '{0}_refmac_2fofcwt.map'.format(pdb_code))
+                diff_map = os.path.join(mr_workdir, '{0}_refmac_fofcwt.map'.format(pdb_code))
 
-                    pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
-                        [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
-                    ))
+                pdb, mtz, map_, dmap, mr_log, ref_log = list(self.adjust_paths_of_files(
+                    [ref_pdb, ref_mtz, ref_map, diff_map, mr_log, ref_log]
+                ))
+                try:
                     self.store_entry_in_rvapi_meta(
                         i + 1, "full", pdb_code, pdb, mtz, map_, dmap, False)
                     self.output_result_files(

--- a/simbad/util/simbad_results.py
+++ b/simbad/util/simbad_results.py
@@ -16,6 +16,7 @@ ID2STR = { LATTICE_ID : 'lattice',
 
 logger = logging.getLogger(__name__)
 
+
 class FileCollection(object):
     """Class for holding results files and annotations"""
     def __init__(self):
@@ -26,6 +27,7 @@ class FileCollection(object):
         self.ref_log = None
         self.ref_map = None
         self.diff_map = None
+
 
 class SimbadResults(object):
     """Class to handle the results from a SIMBAD search


### PR DESCRIPTION
There was a bug in phaser where alternative space groups weren't being checked which has now been fixed. I also added in an hklout argument in phaser_mr/molrep_mr so that any changes in basis that resulted from the alternative space group check would be carried forward to the refinement. 

Additionally, Eugene requested changes to the cleanup algorithm to reduce the amount of space being taken up. To accommodate this I have created a new directory called output_files, which only contains the files required by the GUI. I now remove the mr_search directory which reduces the number of directories/subdirectories and therefore clears up more space. An additional benefit is that it makes the code a little bit tidier. 