### PR TITLE
Change from RMSD estimate to seq ID estimate and bug fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Changed
 - Changed molrep/phaser to output an hkl, this is needed for changes of basis as a result of all/enant searches
 - Altered the cleanup algorithm to completely remove the mr_search directory and instead rely on the newly created output_files directory
 - Altered logging to use enum, closes #81
+- Removed eRMSD calculation and changed to use the seqenence identity directly through phaser, therefore using their equation directly. 
+- Altered phaser so that it outputs the input MTZ with a basis change instead of the phaser output mtz, due to missing r-free columns 
+- Fixed bug in rotation search solution check due to missing argument
 
 0.1.11
 ------

--- a/simbad/core/dat_score.py
+++ b/simbad/core/dat_score.py
@@ -10,9 +10,9 @@ from simbad.core import ScoreBase
 class DatModelScore(ScoreBase):
     """A dat model score storing class"""
 
-    __slots__ = ("pdb_code", "dat_path", "mw_diff", "x", "y", "z", "intrad", "solvent", "nmol", "ermsd")
+    __slots__ = ("pdb_code", "dat_path", "mw_diff", "x", "y", "z", "intrad", "solvent", "nmol")
 
-    def __init__(self, pdb_code, dat_path,  mw_diff, x, y, z, intrad, solvent, nmol, ermsd):
+    def __init__(self, pdb_code, dat_path,  mw_diff, x, y, z, intrad, solvent, nmol):
         self.pdb_code = pdb_code
         self.dat_path = dat_path
         self.mw_diff = mw_diff
@@ -22,11 +22,10 @@ class DatModelScore(ScoreBase):
         self.intrad = intrad
         self.solvent = solvent
         self.nmol = nmol
-        self.ermsd = ermsd
 
     def __repr__(self):
         string = "{name}(pdb_code={pdb_code} dat_path={dat_path} mw_diff={mw_diff} x={x} y={y} z={z} intrad={intrad}" \
-                 "solvent={solvent} nmol={nmol} ermsd={ermsd})"
+                 "solvent={solvent} nmol={nmol})"
         return string.format(name=self.__class__.__name__, **{k: getattr(self, k) for k in self.__slots__})
 
     def _as_dict(self):

--- a/simbad/mr/molrep_mr.py
+++ b/simbad/mr/molrep_mr.py
@@ -473,7 +473,7 @@ class Molrep(object):
 
         ed = mtz_util.ExperimentalData(self.hklin)
         ed.change_space_group(top_sg_code)
-        ed.output_mtz(self.hklin)
+        ed.output_mtz(self.hklout)
     
     @staticmethod
     def molrep(key, logfile):

--- a/simbad/rotsearch/amore_search.py
+++ b/simbad/rotsearch/amore_search.py
@@ -184,7 +184,7 @@ class AmoreRotationSearch(object):
             mw_diff = abs(predicted_molecular_weight - model_molecular_weight)
 
             info = simbad.core.dat_score.DatModelScore(
-                name, dat_model, mw_diff, x, y, z, intrad, solvent_content, None, None
+                name, dat_model, mw_diff, x, y, z, intrad, solvent_content, None
             )
             dat_models.append(info)
 
@@ -386,6 +386,7 @@ ROTA  CROSS  MODEL 1  PKLIM {pklim}  NPIC {npic} STEP {step}"""
                                     refine_type=None,
                                     refine_cycles=0,
                                     output_dir=output_dir,
+                                    sgalternative='none',
                                     tmp_dir=self.tmp_dir,
                                     timeout=30)
             mr.mute = True

--- a/simbad/rotsearch/phaser_rotation_search.py
+++ b/simbad/rotsearch/phaser_rotation_search.py
@@ -41,15 +41,14 @@ class Phaser(object):
     --------
     >>> from simbad.rotsearch.phaser_rotation_search import Phaser
     >>> phaser = Phaser('<hklin>', '<f>', '<i>', '<logfile>', '<nmol>', '<pdbin>', '<pdbout>', '<sgalternative>',
-    >>>                 '<sigf>', '<sigi>', '<solvent>', '<timeout>', '<workdir>', '<autohigh>', '<hires>', '<ermsd>')
+    >>>                 '<sigf>', '<sigi>', '<solvent>', '<timeout>', '<workdir>', '<autohigh>', '<hires>')
     >>> phaser.run()
 
     Files relating to the PHASER run will be contained within the work_dir however the location of the output hkl, pdb
     and logfile can be specified.
     """
 
-    def __init__(self, hklin, f, i, logfile, nmol, pdbin, sigf, sigi, solvent, timeout, work_dir, hires, ermsd):
-        self._ermsd = None
+    def __init__(self, hklin, f, i, logfile, nmol, pdbin, sigf, sigi, solvent, timeout, work_dir, hires):
         self._f = None
         self._hires = None
         self._hklin = None
@@ -63,7 +62,6 @@ class Phaser(object):
         self._timeout = None
         self._work_dir = None
 
-        self.ermsd = ermsd
         self.f = f
         self.hires = hires
         self.hklin = hklin
@@ -76,16 +74,6 @@ class Phaser(object):
         self.solvent = solvent
         self.timeout = timeout
         self.work_dir = work_dir
-
-    @property
-    def ermsd(self):
-        """The estimated rmsd"""
-        return self._ermsd
-
-    @ermsd.setter
-    def ermsd(self, ermsd):
-        """Define the estimated rmsd"""
-        self._ermsd = ermsd
 
     @property
     def f(self):
@@ -229,7 +217,7 @@ class Phaser(object):
             i.setSPAC_HALL(run_mr_data.getSpaceGroupHall())
             i.setCELL6(run_mr_data.getUnitCell())
             i.setROOT("phaser_mr_output")
-            i.addENSE_PDB_RMS("PDB", self.pdbin, self.ermsd)
+            i.addENSE_PDB_ID("PDB", self.pdbin, 0.7)
             i.setCOMP_BY("SOLVENT")
             i.setCOMP_PERC(self.solvent)
             i.addSEAR_ENSE_NUM('PDB', self.nmol)
@@ -273,10 +261,8 @@ if __name__ == "__main__":
                        help="The time in mins before phaser will kill a job")
     group.add_argument('-work_dir', type=str,
                        help="Path to the working directory")
-    group.add_argument('-ermsd', type=float,
-                       help="The estimated rmsd difference")
     args = parser.parse_args()
 
     phaser = Phaser(args.hklin, args.f, args.i, args.logfile, args.nmol, args.pdbin, args.sigf, args.sigi, args.solvent,
-                    args.timeout, args.work_dir, args.hires, args.ermsd)
+                    args.timeout, args.work_dir, args.hires)
     phaser.run()

--- a/simbad/rotsearch/phaser_search.py
+++ b/simbad/rotsearch/phaser_search.py
@@ -156,10 +156,9 @@ class PhaserRotationSearch(object):
                 logger.debug(msg, name, min_solvent_content)
                 continue
             mw_diff = abs(predicted_molecular_weight - pdb_struct.molecular_weight)
-            ermsd = self.calculate_ermsd(pdb_struct.nres, self.eid)
 
             info = simbad.core.dat_score.DatModelScore(
-                name, dat_model, mw_diff, None, None, None, None, solvent_fraction, n_copies, ermsd
+                name, dat_model, mw_diff, None, None, None, None, solvent_fraction, n_copies
             )
             dat_models.append(info)
 
@@ -197,7 +196,6 @@ class PhaserRotationSearch(object):
                               "-solvent", dat_model.solvent,
                               "-nmol", dat_model.nmol,
                               "-work_dir", tmp_dir,
-                              "-ermsd", dat_model.ermsd
                               ]
                 phaser_cmd = " ".join(str(e) for e in phaser_cmd)
 
@@ -265,20 +263,6 @@ class PhaserRotationSearch(object):
         summarize_result(self.search_results,
                          csv_file=csv_file, columns=columns)
 
-    @staticmethod
-    def calculate_ermsd(nres, id):
-        """Calculate the estimated rmsd based on the number of residues and sequence id"""
-
-        if 0 > id < 100:
-            raise RuntimeError("Sequence id must be a number between 0 and 100")
-
-        if nres < 0:
-            raise RuntimeError( "The number of residues must be greater than 0")
-
-        return (1.54967686e+00 + 1.69034597e-03 * nres + -2.57055256e-02 * id + -5.92896517e-07 * nres ** 2
-                + -1.68255006e-05 * nres * id + 2.03689221e-04 * id ** 2 + 1.01170096e-10 * nres ** 3
-                + 2.45170962e-09 * nres ** 2 * id + 5.10824965e-08 * nres * id ** 2 + -7.01029519e-07 * id ** 3)
-
     @property
     def search_results(self):
         return sorted(self._search_results, key=lambda x: float(x.llg), reverse=True)[:self.max_to_keep]
@@ -322,6 +306,7 @@ class PhaserRotationSearch(object):
                                         refine_type=None,
                                         refine_cycles=0,
                                         output_dir=output_dir,
+                                        sgalternative='none',
                                         tmp_dir=self.tmp_dir,
                                         timeout=30)
                 mr.mute = True


### PR DESCRIPTION
- The main change here is removing the eRMSD calculation and instead using the sequence identity directly in phaser. This should result in a better RMSD estimate in general. 

- I was using the phaser output mtz for refinement so that the MTZ would have the correct space group following a basis change. Unfortunately using this lost the r-free flag, so I've changed this from the phaser output MTZ to the input MTZ with a basis change where necessary. 

- Bug fixes, fixed a typo in `molrep_mr` module and added a missing argument to the check_success functions in `amore_search` and `phaser_rotation_search`.
